### PR TITLE
Store test signatures in a Dictionary

### DIFF
--- a/GoogleTestAdapter/Core/Helpers/Extensions.cs
+++ b/GoogleTestAdapter/Core/Helpers/Extensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// This file has been modified by Microsoft on 7/2017.
+
+using System.Collections.Generic;
 using GoogleTestAdapter.Model;
 
 namespace GoogleTestAdapter.Helpers

--- a/GoogleTestAdapter/Core/Helpers/Extensions.cs
+++ b/GoogleTestAdapter/Core/Helpers/Extensions.cs
@@ -37,6 +37,12 @@ namespace GoogleTestAdapter.Helpers
             return string.IsNullOrWhiteSpace(theString) ? theString : theString + appendix;
         }
 
+        internal static TV GetValue<TK, TV>(this IDictionary<TK, TV> dict, TK key, TV defaultValue = default(TV))
+        {
+            TV value;
+            return dict.TryGetValue(key, out value) ? value : defaultValue;
+        }
+
     }
 
 }

--- a/GoogleTestAdapter/Core/Helpers/Extensions.cs
+++ b/GoogleTestAdapter/Core/Helpers/Extensions.cs
@@ -37,12 +37,6 @@ namespace GoogleTestAdapter.Helpers
             return string.IsNullOrWhiteSpace(theString) ? theString : theString + appendix;
         }
 
-        internal static TV GetValue<TK, TV>(this IDictionary<TK, TV> dict, TK key, TV defaultValue = default(TV))
-        {
-            TV value;
-            return dict.TryGetValue(key, out value) ? value : defaultValue;
-        }
-
     }
 
 }

--- a/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// This file has been modified by Microsoft on 7/2017.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
@@ -62,7 +62,7 @@ namespace GoogleTestAdapter.TestCases
                     .SelectMany(descriptor => _signatureCreator.GetTestMethodSignatures(descriptor).Select(s => Tuple.Create(s, descriptor)))
                     .ToDictionary(testCase => testCase.Item1, testCase => testCase.Item2);
                 var testCaseLocations = GetTestCaseLocations(testMethods.Keys, _settings.GetPathExtension(_executable));
-                return testMethods.Select(testMethod => CreateTestCase(testMethod.Value, testCaseLocations[testMethod.Key])).ToList();
+                return testMethods.Select(testMethod => CreateTestCase(testMethod.Value, testCaseLocations.GetValue(testMethod.Key))).ToList();
             }
 
             return testCaseDescriptors.Select(CreateTestCase).ToList();

--- a/GoogleTestAdapter/Core/TestCases/TestCaseResolver.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseResolver.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// This file has been modified by Microsoft on 7/2017.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;


### PR DESCRIPTION
This reduces runtime for test discovery from quadratic to linear.