### PR TITLE
Fix new project wizard to look at major version number not revision number

### DIFF
--- a/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
+++ b/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
@@ -158,7 +158,7 @@ namespace Microsoft.NewProjectWizard
 
                     string versionString;
 
-                    if (latestSdk.TargetPlatformVersion.Revision >= 10)
+                    if (latestSdk.TargetPlatformVersion.Major >= 10)
                     {
                         List<Platform> allPlatformsForLatestSdk = ToolLocationHelper.GetPlatformsForSDK("Windows", latestSdk.TargetPlatformVersion)
                             .Select(moniker => TryParsePlatformVersion(moniker))


### PR DESCRIPTION
This fixes build for newly created projects created with Win10 SDK