### PR TITLE
Address FxCop globalization rules

### DIFF
--- a/GoogleTestAdapter/Core/TestCases/NewTestCaseResolver.cs
+++ b/GoogleTestAdapter/Core/TestCases/NewTestCaseResolver.cs
@@ -1,4 +1,4 @@
-﻿// This file has been modified by Microsoft on 8/2017.
+﻿// This file has been modified by Microsoft on 9/2017.
 
 using System;
 using System.Collections.Generic;
@@ -106,7 +106,7 @@ namespace GoogleTestAdapter.TestCases
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (SourceFileLocation nativeTraitSymbol in allTraitSymbols)
             {
-                if (nativeSymbol.Symbol.StartsWith(nativeTraitSymbol.TestClassSignature))
+                if (nativeSymbol.Symbol.StartsWith(nativeTraitSymbol.TestClassSignature, StringComparison.Ordinal))
                 {
                     int lengthOfSerializedTrait = nativeTraitSymbol.Symbol.Length - nativeTraitSymbol.IndexOfSerializedTrait - TraitAppendix.Length;
                     string serializedTrait = nativeTraitSymbol.Symbol.Substring(nativeTraitSymbol.IndexOfSerializedTrait, lengthOfSerializedTrait);

--- a/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
+++ b/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// This file has been modified by Microsoft on 9/2017.
+
+using System;
 using System.Text.RegularExpressions;
 
 namespace GoogleTestAdapter.TestCases
@@ -30,7 +32,7 @@ namespace GoogleTestAdapter.TestCases
         public void ReportLine(string line)
         {
             string trimmedLine = line.Trim('.', '\n', '\r');
-            if (trimmedLine.StartsWith("  "))
+            if (trimmedLine.StartsWith("  ", StringComparison.Ordinal))
             {
                 TestCaseDescriptor descriptor = CreateDescriptor(_currentSuite, trimmedLine.Substring(2));
                 TestCaseDescriptorCreated?.Invoke(this,
@@ -86,7 +88,7 @@ namespace GoogleTestAdapter.TestCases
 
         private static string GetEnclosedTypeParam(string typeParam)
         {
-            if (typeParam.EndsWith(">"))
+            if (typeParam.EndsWith(">", StringComparison.Ordinal))
             {
                 typeParam += " ";
             }

--- a/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
@@ -1,4 +1,4 @@
-﻿// This file has been modified by Microsoft on 8/2017.
+﻿// This file has been modified by Microsoft on 9/2017.
 
 using System;
 using System.Collections.Generic;
@@ -249,7 +249,7 @@ namespace GoogleTestAdapter.TestCases
         internal static string StripTestSymbolNamespace(string symbol)
         {
             var suffixLength = GoogleTestConstants.TestBodySignature.Length;
-            var namespaceEnd = symbol.LastIndexOf("::", symbol.Length - suffixLength - 1);
+            var namespaceEnd = symbol.LastIndexOf("::", symbol.Length - suffixLength - 1, StringComparison.Ordinal);
             var nameStart = namespaceEnd >= 0 ? namespaceEnd + 2 : 0;
             return symbol.Substring(nameStart);
         }

--- a/GoogleTestAdapter/Core/TestResults/ErrorMessageParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/ErrorMessageParser.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// This file has been modified by Microsoft on 9/2017.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -68,7 +70,7 @@ namespace GoogleTestAdapter.TestResults
 
             if (_outputBeforeFirstFailure != "")
             {
-                if (!_outputBeforeFirstFailure.EndsWith("\n") && !_outputBeforeFirstFailure.EndsWith("\r\n"))
+                if (!_outputBeforeFirstFailure.EndsWith("\n", StringComparison.Ordinal) && !_outputBeforeFirstFailure.EndsWith("\r\n", StringComparison.Ordinal))
                     _outputBeforeFirstFailure += "\n";
                 ErrorMessage = $"{_outputBeforeFirstFailure}{ErrorMessage}";
             }

--- a/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
@@ -201,17 +201,17 @@ namespace GoogleTestAdapter.TestResults
 
         public static bool IsRunLine(string line)
         {
-            return line.StartsWith(Run);
+            return line.StartsWith(Run, StringComparison.Ordinal);
         }
 
         public static bool IsPassedLine(string line)
         {
-            return line.StartsWith(Passed);
+            return line.StartsWith(Passed, StringComparison.Ordinal);
         }
 
         public static bool IsFailedLine(string line)
         {
-            return line.StartsWith(Failed);
+            return line.StartsWith(Failed, StringComparison.Ordinal);
         }
 
         public static string RemovePrefix(string line)

--- a/GoogleTestAdapter/DiaResolver/DiaFactory.cs
+++ b/GoogleTestAdapter/DiaResolver/DiaFactory.cs
@@ -48,7 +48,7 @@ namespace GoogleTestAdapter.DiaResolver
             return IntPtr.Size == 4;
         }
 
-        [DllImport("Kernel32.dll")]
+        [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
         private static extern IntPtr LoadLibrary(string path);
 
         [DllImport(DiaDll, ExactSpelling = true, PreserveSig = false)]

--- a/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
+++ b/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TemplateWizard;
 using NewProjectWizard.Properties;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -129,7 +130,7 @@ namespace Microsoft.NewProjectWizard
                 }
                 catch (Exception)
                 {
-                    MessageBox.Show(Resources.NuGetInteropNotFound);
+                    ShowRtlAwareMessageBox(Resources.NuGetInteropNotFound);
                     throw;
                 }
 
@@ -152,7 +153,7 @@ namespace Microsoft.NewProjectWizard
 
                     if (latestSdk == null)
                     {
-                        MessageBox.Show(Resources.WinSDKNotFound);
+                        ShowRtlAwareMessageBox(Resources.WinSDKNotFound);
                         throw new WizardCancelledException(Resources.WinSDKNotFound);
                     }
 
@@ -168,7 +169,7 @@ namespace Microsoft.NewProjectWizard
 
                         if (latestPlatform == null)
                         {
-                            MessageBox.Show(Resources.WinSDKNotFound);
+                            ShowRtlAwareMessageBox(Resources.WinSDKNotFound);
                             throw new WizardCancelledException(Resources.WinSDKNotFound);
                         }
 
@@ -198,6 +199,22 @@ namespace Microsoft.NewProjectWizard
             return true;
         }
 #endregion
+
+        private void ShowRtlAwareMessageBox(string text)
+        {
+            MessageBoxOptions options = 0;
+            if (CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft)
+            {
+                options |= MessageBoxOptions.RtlReading | MessageBoxOptions.RightAlign;
+            }
+            MessageBox.Show(
+                text,
+                Resources.WizardTitle,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error,
+                MessageBoxDefaultButton.Button1,
+                options);
+        }
 
         private static IEnumerable<TargetPlatformSDK> GetAllPlatformSdks()
         {

--- a/GoogleTestAdapter/TestAdapter/Framework/VsVersion.cs
+++ b/GoogleTestAdapter/TestAdapter/Framework/VsVersion.cs
@@ -1,4 +1,4 @@
-﻿// This file has been modified by Microsoft on 8/2017.
+﻿// This file has been modified by Microsoft on 9/2017.
 
 using System;
 using System.Diagnostics;
@@ -8,6 +8,7 @@ using System.Linq;
 using GoogleTestAdapter.Common;
 using GoogleTestAdapter.TestAdapter.Helpers;
 using Process = System.Diagnostics.Process;
+using System.Globalization;
 
 namespace GoogleTestAdapter.TestAdapter.Framework
 {
@@ -97,12 +98,12 @@ namespace GoogleTestAdapter.TestAdapter.Framework
         private static Process FindVsOrVsTestConsoleExe()
         {
             var process = Process.GetCurrentProcess();
-            string executable = Path.GetFileName(process.MainModule.FileName).Trim().ToLower();
-            while (executable != null && executable != "devenv.exe" && executable != "vstest.console.exe")
+            string executable = Path.GetFileName(process.MainModule.FileName).Trim().ToUpperInvariant();
+            while (executable != null && executable != "DEVENV.EXE" && executable != "VSTEST.CONSOLE.EXE")
             {
                 process = ParentProcessUtils.GetParentProcess(process.Id);
-                executable = process != null 
-                    ? Path.GetFileName(process.MainModule.FileName).Trim().ToLower()
+                executable = process != null
+                    ? Path.GetFileName(process.MainModule.FileName).Trim().ToUpperInvariant()
                     : null;
             }
             return process;

--- a/Tools/GoogleTestAdapter.FxCop
+++ b/Tools/GoogleTestAdapter.FxCop
@@ -44,6 +44,7 @@
  </Targets>
  <Rules>
   <RuleFiles>
+   <RuleFile Name="$(FxCopDir)\Rules\GlobalizationRules.dll" Enabled="True" AllRulesEnabled="True" />
    <RuleFile Name="$(FxCopDir)\Rules\MSInternalRules.dll" Enabled="True" AllRulesEnabled="True" />
    <RuleFile Name="$(FxCopDir)\Rules\SecurityCryptographyRules.dll" Enabled="True" AllRulesEnabled="True" />
    <RuleFile Name="$(FxCopDir)\Rules\SecurityRules.dll" Enabled="True" AllRulesEnabled="True" />
@@ -323,6 +324,15 @@
      </Message>
     </Messages>
    </Namespace>
+   <Namespace Name="NewProjectWizard.Properties">
+    <Messages>
+     <Message TypeName="DeclareTypesInMicrosoftOrSystemNamespace" Category="Microsoft.MSInternal" CheckId="CA904" Created="2017-09-15 23:25:59Z">
+      <Issue>
+       <Item>NewProjectWizard.Properties</Item>
+      </Issue>
+     </Message>
+    </Messages>
+   </Namespace>
    <Namespace Name="VSLangProj">
     <Messages>
      <Message TypeName="DeclareTypesInMicrosoftOrSystemNamespace" Category="Microsoft.MSInternal" CheckId="CA904" Status="Excluded" Created="2017-07-27 19:02:02Z">
@@ -337,6 +347,15 @@
      </Message>
     </Messages>
    </Namespace>
+   <Namespace Name="XamlGeneratedNamespace">
+    <Messages>
+     <Message TypeName="DeclareTypesInMicrosoftOrSystemNamespace" Category="Microsoft.MSInternal" CheckId="CA904" Created="2017-09-15 23:25:59Z">
+      <Issue>
+       <Item>XamlGeneratedNamespace</Item>
+      </Issue>
+     </Message>
+    </Messages>
+   </Namespace>
   </Namespaces>
   <Notes>
    <User Name="lukaszme">
@@ -345,8 +364,19 @@
    </User>
   </Notes>
   <Rules>
+   <Rule TypeName="AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies" Category="Microsoft.MSInternal" CheckId="CA908">
+    <Resolution Name="Method">Replace the generic method {0} called in {1} with a generic method that does not require JIT compilation at runtime for precompiled assemblies. If this is not an precompiled assembly this message should be suppressed or this rule should be disabled.</Resolution>
+   </Rule>
    <Rule TypeName="DeclareTypesInMicrosoftOrSystemNamespace" Category="Microsoft.MSInternal" CheckId="CA904">
     <Resolution Name="Default">Redefine the types in namespace '{0}' in the Microsoft or System namespace. Public types that will never ship externally can be defined in the MS namespace. Consider disabling this rule when analyzing code that does not ship externally.</Resolution>
+   </Rule>
+   <Rule TypeName="SpecifyIFormatProvider" Category="Microsoft.Globalization" CheckId="CA1305">
+    <Resolution Name="IFormatProviderAlternate">Because the behavior of {0} could vary based on the current user's locale settings, replace this call in {1} with a call to {2}. If the result of {2} will be based on input from the user, specify {3} as the 'IFormatProvider' parameter. Otherwise, if the result will based on input stored and accessed by software, such as when it is loaded from disk or from a database, specify {4}.</Resolution>
+    <Resolution Name="IFormatProviderAlternateString">Because the behavior of {0} could vary based on the current user's locale settings, replace this call in {1} with a call to {2}. If the result of {2} will be displayed to the user, specify {3} as the 'IFormatProvider' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify {4}.</Resolution>
+   </Rule>
+   <Rule TypeName="SpecifyMarshalingForPInvokeStringArguments" Category="Microsoft.Globalization" CheckId="CA2101">
+    <Resolution Name="FieldImplicitAnsi">To reduce security risk, marshal field {0} as Unicode, by setting StructLayout.CharSet on {1} to CharSet.Unicode, or by explicitly marshaling the field as UnmanagedType.LPWStr. If you need to marshal this string as ANSI or system-dependent, specify MarshalAs explicitly, use the BestFitMapping attribute to turn best-fit mapping off, and for added security, to turn ThrowOnUnmappableChar on.</Resolution>
+    <Resolution Name="Parameter">To reduce security risk, marshal parameter {0} as Unicode, by setting DllImport.CharSet to CharSet.Unicode, or by explicitly marshaling the parameter as UnmanagedType.LPWStr. If you need to marshal this string as ANSI or system-dependent, set BestFitMapping=false; for added security, also set ThrowOnUnmappableChar=true.</Resolution>
    </Rule>
   </Rules>
  </FxCopReport>


### PR DESCRIPTION
Most fixes are related to culture invariance during string comparison. FxCop still complains about `SpecifyMarshalingForPInvokeStringArguments` in `ProcessExecutor.NativeMethods`, but based on code inspection these issues appear to already be resolved. Additionally, FxCop complains about always specifying `CultureInfo.CurrentCulture` when formatting strings, but this is a low-priority issue with the potential to make the code much noisier.