### PR TITLE
Add setup components for use with insertion into VS

### DIFF
--- a/GoogleTestAdapter/Packaging.TAfGT/Packaging.TAfGT.csproj
+++ b/GoogleTestAdapter/Packaging.TAfGT/Packaging.TAfGT.csproj
@@ -26,6 +26,7 @@
     <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
     <BypassVsixValidation>true</BypassVsixValidation>
     <DeployExtension Condition="'$(TestAdapterFlavor)' != 'TAfGT'">false</DeployExtension>
+    <IsProductComponent>true</IsProductComponent>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/GoogleTestAdapter/Packaging.TAfGT/source.extension.vsixmanifest
+++ b/GoogleTestAdapter/Packaging.TAfGT/source.extension.vsixmanifest
@@ -4,6 +4,7 @@
     <Identity Id="GoogleTestAdapterVSIX.8486b54e-5768-482b-b224-7d069ca509d8" Version="0.1.0.0" Language="en-US" Publisher="Christian Soltenborn, Jonas Gefele" />
     <DisplayName>Test Adapter for Google Test</DisplayName>
     <Description xml:space="preserve">Enables Visual Studio's testing tools with unit tests written for Google Test.</Description>
+    <PackageId>Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest</PackageId>
     <MoreInfo>https://go.microsoft.com/fwlink/?linkid=848768</MoreInfo>
     <License>use.txt</License>
     <ReleaseNotes>ReleaseNotes.txt</ReleaseNotes>

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
+  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" />
+
+  <PropertyGroup>
+    <OutputArchitecture>neutral</OutputArchitecture>
+    <OutputLocalized>false</OutputLocalized>
+    <OutputName>Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest</OutputName>
+    <OutputType>manifest</OutputType>
+    <IsPackage>true</IsPackage>
+    <VSGeneralVersion>15.0</VSGeneralVersion>
+    <VSNextGeneralVersion>16.0</VSNextGeneralVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <VsixOutDir>$(OutputPath)..\Packaging.TAfGT</VsixOutDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Package Include="Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swr" />
+  </ItemGroup>
+
+  <Target Name="SetVsixProperties" BeforeTargets="Build" DependsOnTargets="GetBuildVersion">
+    <PropertyGroup>
+      <!-- Variables added here will be usable in the swr file.  This is a semi colon delimited
+           list of name=value items.  Use $(name) in the swr file to reference the variable.
+      -->
+      <PackagePreprocessorDefinitions>
+        $(PackagePreprocessorDefinitions);
+        VsixOutDir=$(VsixOutDir);
+        Version=$(BuildVersion);
+        VSGeneralVersion=$(VSGeneralVersion);
+        VSNextGeneralVersion=$(VSNextGeneralVersion);
+      </PackagePreprocessorDefinitions>
+    </PropertyGroup>
+  </Target>
+
+  <!-- MicroBuild plugin fails if GetNativeManifest is not found for some reason -->
+  <Target Name="GetNativeManifest" />
+  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" />
+</Project>

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" />
-
   <PropertyGroup>
     <OutputArchitecture>neutral</OutputArchitecture>
     <OutputLocalized>false</OutputLocalized>
@@ -14,6 +12,7 @@
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
+  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" />
 
   <PropertyGroup>
     <VsixOutDir>$(OutputPath)..\Packaging.TAfGT</VsixOutDir>

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
   <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" />
 
   <PropertyGroup>
@@ -11,7 +10,10 @@
     <IsPackage>true</IsPackage>
     <VSGeneralVersion>15.0</VSGeneralVersion>
     <VSNextGeneralVersion>16.0</VSNextGeneralVersion>
+    <SolutionName>TestAdapterForGoogleTest</SolutionName>
   </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
 
   <PropertyGroup>
     <VsixOutDir>$(OutputPath)..\Packaging.TAfGT</VsixOutDir>

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
@@ -39,4 +39,5 @@
   <!-- MicroBuild plugin fails if GetNativeManifest is not found for some reason -->
   <Target Name="GetNativeManifest" />
   <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" />
+  <Import Project="$(NuGetPackages)Nerdbank.GitVersioning.1.4.30\build\dotnet\Nerdbank.GitVersioning.targets" />
 </Project>

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
@@ -8,7 +8,7 @@
     <IsPackage>true</IsPackage>
     <VSGeneralVersion>15.0</VSGeneralVersion>
     <VSNextGeneralVersion>16.0</VSNextGeneralVersion>
-    <SolutionName>TestAdapterForGoogleTest</SolutionName>
+    <SolutionName>GoogleTestAdapter</SolutionName>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swr
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swr
@@ -1,0 +1,14 @@
+use vs
+
+package name=Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest
+        version=$(Version)
+        vs.package.type=vsix
+        vs.package.installSize=22265856
+        vs.package.vsixId=GoogleTestAdapterVSIX.8486b54e-5768-482b-b224-7d069ca509d8
+
+vs.payloads
+  vs.payload source=$(VsixOutDir)\Packaging.TAfGT.vsix
+
+vs.dependencies
+  vs.dependency id=Microsoft.VisualStudio.MinShell
+                version=[$(VSGeneralVersion),$(VSNextGeneralVersion))

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swr
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swr
@@ -5,7 +5,7 @@ package name=Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest
         vs.package.type=vsix
         vs.package.installSize=22265856
         vs.package.vsixId=GoogleTestAdapterVSIX.8486b54e-5768-482b-b224-7d069ca509d8
-        vs.package.extensionDir=[installdir]\\Common7\\IDE\\CommonExtensions\\VC\\TestAdapterForGoogleTest
+        vs.package.extensionDir=[installdir]\Common7\IDE\CommonExtensions\VC\TestAdapterForGoogleTest
 
 vs.payloads
   vs.payload source=$(VsixOutDir)\Packaging.TAfGT.vsix

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swr
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swr
@@ -5,10 +5,7 @@ package name=Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest
         vs.package.type=vsix
         vs.package.installSize=22265856
         vs.package.vsixId=GoogleTestAdapterVSIX.8486b54e-5768-482b-b224-7d069ca509d8
+        vs.package.extensionDir=[installdir]\\Common7\\IDE\\CommonExtensions\\VC\\TestAdapterForGoogleTest
 
 vs.payloads
   vs.payload source=$(VsixOutDir)\Packaging.TAfGT.vsix
-
-vs.dependencies
-  vs.dependency id=Microsoft.VisualStudio.MinShell
-                version=[$(VSGeneralVersion),$(VSNextGeneralVersion))

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
+  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" />
+
+  <PropertyGroup>
+    <FinalizeManifest>true</FinalizeManifest>
+    <FinalizeSkipLayout>true</FinalizeSkipLayout>
+
+    <!-- Set ValidateManifest to false because the tooling currently doesn't
+     support finding the dependency for MinShell outside of VS -->
+    <ValidateManifest>false</ValidateManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.json" />
+  </ItemGroup>
+
+  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" /> 
+</Project> 

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" />
-
   <PropertyGroup>
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
@@ -10,7 +7,11 @@
     <!-- Set ValidateManifest to false because the tooling currently doesn't
      support finding the dependency for MinShell outside of VS -->
     <ValidateManifest>false</ValidateManifest>
+    <SolutionName>GoogleTestAdapter</SolutionName>
   </PropertyGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
+  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" />
   
   <ItemGroup>
     <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.json" />

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
@@ -11,10 +11,6 @@
      support finding the dependency for MinShell outside of VS -->
     <ValidateManifest>false</ValidateManifest>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj" />
-  </ItemGroup>
   
   <ItemGroup>
     <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.json" />

--- a/swix/packages.config
+++ b/swix/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" developmentDependency="true" />
+  <package id="Nerdbank.GitVersioning" version="1.4.30" targetFramework="net46" developmentDependency="true" />
+</packages>

--- a/swix/res/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
+++ b/swix/res/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
+  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" />
+
+  <PropertyGroup>
+    <OutputArchitecture>neutral</OutputArchitecture>
+    <OutputLocalized>false</OutputLocalized>
+    <OutputName>Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest</OutputName>
+    <OutputType>manifest</OutputType>
+    <IsPackage>true</IsPackage>
+    <VSGeneralVersion>15.0</VSGeneralVersion>
+    <VSNextGeneralVersion>16.0</VSNextGeneralVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <VsixOutDir>$(OutputPath)..\Packaging.TAfGT</VsixOutDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Package Include="Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swr" />
+  </ItemGroup>
+
+  <Target Name="SetVsixProperties" BeforeTargets="Build" DependsOnTargets="GetBuildVersion">
+    <PropertyGroup>
+      <!-- Variables added here will be usable in the swr file.  This is a semi colon delimited
+           list of name=value items.  Use $(name) in the swr file to reference the variable.
+      -->
+      <PackagePreprocessorDefinitions>
+        $(PackagePreprocessorDefinitions);
+        VsixOutDir=$(VsixOutDir);
+        Version=$(BuildVersion);
+        VSGeneralVersion=$(VSGeneralVersion);
+        VSNextGeneralVersion=$(VSNextGeneralVersion);
+      </PackagePreprocessorDefinitions>
+    </PropertyGroup>
+  </Target>
+
+  <!-- MicroBuild plugin fails if GetNativeManifest is not found for some reason -->
+  <Target Name="GetNativeManifest" />
+  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" />
+</Project>

--- a/swix/res/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swr
+++ b/swix/res/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swr
@@ -1,0 +1,14 @@
+use vs
+
+package name=Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest
+        version=$(Version)
+        vs.package.type=vsix
+        vs.package.installSize=22265856
+        vs.package.vsixId=GoogleTestAdapterVSIX.8486b54e-5768-482b-b224-7d069ca509d8
+
+vs.payloads
+  vs.payload source=$(VsixOutDir)\Packaging.TAfGT.vsix
+
+vs.dependencies
+  vs.dependency id=Microsoft.VisualStudio.MinShell
+                version=[$(VSGeneralVersion),$(VSNextGeneralVersion))

--- a/swix/res/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
+++ b/swix/res/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
+  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" />
+
+  <PropertyGroup>
+    <FinalizeManifest>true</FinalizeManifest>
+    <FinalizeSkipLayout>true</FinalizeSkipLayout>
+
+    <!-- Set ValidateManifest to false because the tooling currently doesn't
+     support finding the dependency for MinShell outside of VS -->
+    <ValidateManifest>false</ValidateManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.swixproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.json" />
+  </ItemGroup>
+
+  <Import Project="$(NuGetPackages)MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" /> 
+</Project> 


### PR DESCRIPTION
We have microbuild set up to build the swixproj and vsmanproj to generate a vsman for us to merge into the main setup for Visual Studio. Currently the projects under swix/res aren't being used but are there to support localization which is coming soon. Verified the installation with a VAL build on the VS side pulling in a VAL build from this side and setup was all working.