### PR TITLE
Use different pdb names for static vs dyn libs and update all version refs to new version

### DIFF
--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vstemplate
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vstemplate
@@ -26,7 +26,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="GoogleTestAdapterVSIX.d3b8e668-8582-4be9-ab42-aaf872704ef3">
-      <package id="$nugetpackage$" version="1.8.1" />
+      <package id="$nugetpackage$" version="1.8.1.2" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/GoogleTestAdapter/Packaging.TAfGT/Packaging.TAfGT.csproj
+++ b/GoogleTestAdapter/Packaging.TAfGT/Packaging.TAfGT.csproj
@@ -49,15 +49,15 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\Packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1.nupkg">
+    <Content Include="..\Packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.2.nupkg">
       <CopyToOutputDirectory>CopyIfNewer</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.1.nupkg">
+    <Content Include="..\Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.2.nupkg">
       <CopyToOutputDirectory>CopyIfNewer</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.1.nupkg">
+    <Content Include="..\Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.2.nupkg">
       <CopyToOutputDirectory>CopyIfNewer</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>

--- a/GoogleTestAdapter/Packaging.TAfGT/source.extension.vsixmanifest
+++ b/GoogleTestAdapter/Packaging.TAfGT/source.extension.vsixmanifest
@@ -28,9 +28,9 @@
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="NewProjectWizard" Path="|NewProjectWizard|" AssemblyName="|NewProjectWizard;AssemblyName|" />
-        <Asset Type="Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.nupkg" d:Source="File" Path="Packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.nupkg" d:Source="File" Path="Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.nupkg" d:VsixSubPath="Packages" />
-        <Asset Type="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.nupkg" d:Source="File" Path="Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.2.nupkg" d:Source="File" Path="Packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.2.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.2.nupkg" d:Source="File" Path="Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.2.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.2.nupkg" d:Source="File" Path="Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.2.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="GoogleTestProjectTemplate" d:TargetPath="|GoogleTestProjectTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="GoogleTestItemTemplate" d:TargetPath="|GoogleTestItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
     </Assets>

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -278,9 +278,9 @@ function Build-NuGet {
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest_main.pdb" -Destination "$DestinationPath\Release\gtest_main.pdb"
         } else {
             Copy-CreateItem -Path "$BuildPath\Debug\gtestd.lib"                    -Destination "$DestinationPath\Debug\gtestd.lib"
-            Copy-CreateItem -Path "$BuildPath\gtest.dir\Debug\gtest.pdb"           -Destination "$DestinationPath\Debug\gtestd.pdb"
+            Copy-CreateItem -Path "$BuildPath\gtest.dir\Debug\gtest.pdb"           -Destination "$DestinationPath\Debug\gtest.pdb"
             Copy-CreateItem -Path "$BuildPath\Debug\gtest_maind.lib"               -Destination "$DestinationPath\Debug\gtest_maind.lib"
-            Copy-CreateItem -Path "$BuildPath\gtest_main.dir\Debug\gtest_main.pdb" -Destination "$DestinationPath\Debug\gtest_maind.pdb"
+            Copy-CreateItem -Path "$BuildPath\gtest_main.dir\Debug\gtest_main.pdb" -Destination "$DestinationPath\Debug\gtest_main.pdb"
 
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest.lib"                     -Destination "$DestinationPath\Release\gtest.lib"
             Copy-CreateItem -Path "$BuildPath\gtest.dir\RelWithDebInfo\gtest.pdb"           -Destination "$DestinationPath\Release\gtest.pdb"

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -278,9 +278,9 @@ function Build-NuGet {
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest_main.pdb" -Destination "$DestinationPath\Release\gtest_main.pdb"
         } else {
             Copy-CreateItem -Path "$BuildPath\Debug\gtestd.lib"                    -Destination "$DestinationPath\Debug\gtestd.lib"
-            Copy-CreateItem -Path "$BuildPath\gtest.dir\Debug\gtestd.pdb"           -Destination "$DestinationPath\Debug\gtestd.pdb"
+            Copy-CreateItem -Path "$BuildPath\gtest.dir\Debug\gtest.pdb"           -Destination "$DestinationPath\Debug\gtestd.pdb"
             Copy-CreateItem -Path "$BuildPath\Debug\gtest_maind.lib"               -Destination "$DestinationPath\Debug\gtest_maind.lib"
-            Copy-CreateItem -Path "$BuildPath\gtest_main.dir\Debug\gtest_maind.pdb" -Destination "$DestinationPath\Debug\gtest_maind.pdb"
+            Copy-CreateItem -Path "$BuildPath\gtest_main.dir\Debug\gtest_main.pdb" -Destination "$DestinationPath\Debug\gtest_maind.pdb"
 
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest.lib"                     -Destination "$DestinationPath\Release\gtest.lib"
             Copy-CreateItem -Path "$BuildPath\gtest.dir\RelWithDebInfo\gtest.pdb"           -Destination "$DestinationPath\Release\gtest.pdb"

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -278,9 +278,9 @@ function Build-NuGet {
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest_main.pdb" -Destination "$DestinationPath\Release\gtest_main.pdb"
         } else {
             Copy-CreateItem -Path "$BuildPath\Debug\gtestd.lib"                    -Destination "$DestinationPath\Debug\gtestd.lib"
-            Copy-CreateItem -Path "$BuildPath\gtest.dir\Debug\gtest.pdb"           -Destination "$DestinationPath\Debug\gtest.pdb"
+            Copy-CreateItem -Path "$BuildPath\gtest.dir\Debug\gtestd.pdb"           -Destination "$DestinationPath\Debug\gtestd.pdb"
             Copy-CreateItem -Path "$BuildPath\Debug\gtest_maind.lib"               -Destination "$DestinationPath\Debug\gtest_maind.lib"
-            Copy-CreateItem -Path "$BuildPath\gtest_main.dir\Debug\gtest_main.pdb" -Destination "$DestinationPath\Debug\gtest_main.pdb"
+            Copy-CreateItem -Path "$BuildPath\gtest_main.dir\Debug\gtest_maind.pdb" -Destination "$DestinationPath\Debug\gtest_maind.pdb"
 
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest.lib"                     -Destination "$DestinationPath\Release\gtest.lib"
             Copy-CreateItem -Path "$BuildPath\gtest.dir\RelWithDebInfo\gtest.pdb"           -Destination "$DestinationPath\Release\gtest.pdb"

--- a/GoogleTestNuGet/googletest.nuspec.tt
+++ b/GoogleTestNuGet/googletest.nuspec.tt
@@ -5,7 +5,7 @@
 <package>
   <metadata>
     <id><#= PackageName #></id>
-    <version>1.8.1.1</version>
+    <version>1.8.1.2</version>
     <authors>Microsoft</authors>
     <owners>microsoft,visualcpp</owners>
     <projectUrl>https://github.com/Microsoft/TestAdapterForGoogleTest</projectUrl>

--- a/GoogleTestNuGet/googletest.targets.tt
+++ b/GoogleTestNuGet/googletest.targets.tt
@@ -33,9 +33,12 @@
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtestd.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtest_maind.dll" Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" />
+      <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtestd.pdb" />
+      <ReferenceCopyLocalPaths Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtest_maind.pdb" />
+    <# } else { #>
+      <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtest.pdb" />
+      <ReferenceCopyLocalPaths Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtest_main.pdb" />
     <# } #>
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtestd.pdb" />
-    <ReferenceCopyLocalPaths Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtest_maind.pdb" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(Platform)' == 'x64' And '$(Disable-<#= PackageNameDashes #>)' == ''">
     <# if (ConfigurationType == "dyn") { #>
@@ -49,16 +52,20 @@
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtestd.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtest_maind.dll" Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" />
+      <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtestd.pdb" />
+      <ReferenceCopyLocalPaths Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtest_maind.pdb" />
+    <# } else { #>
+      <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtest.pdb" />
+      <ReferenceCopyLocalPaths Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtest_main.pdb" />
     <# } #>
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtestd.pdb" />
-    <ReferenceCopyLocalPaths Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtest_maind.pdb" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Release' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86') And '$(Disable-<#= PackageNameDashes #>)' == ''">
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest_main.dll" Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" />
+    <# } else { #>
+      <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest.pdb" />
+      <ReferenceCopyLocalPaths Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest_main.pdb" />
     <# } #>
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest.pdb" />
-    <ReferenceCopyLocalPaths Condition="'$(<#= PackageNameDashes #>-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest_main.pdb" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The previous fix for dynamic pdbs had an unfortunate side-effect of breaking the static pdbs. This treats them differently since Google Test gives us different names. This also fixes nuget package reference for the updated extension with the new nuget package version.