### PR TITLE
Rename GlobalRunSettings to not overlap with external GTA

### DIFF
--- a/GoogleTestAdapter/TestAdapter.Tests/Helpers/RunSettingsServiceUnderTest.cs
+++ b/GoogleTestAdapter/TestAdapter.Tests/Helpers/RunSettingsServiceUnderTest.cs
@@ -6,7 +6,7 @@ namespace GoogleTestAdapter.TestAdapter.Helpers
     {
         private readonly string _solutionRunSettingsFile;
 
-        internal RunSettingsServiceUnderTest(IGlobalRunSettings globalRunSettings, string solutionRunSettingsFile) 
+        internal RunSettingsServiceUnderTest(IGlobalRunSettings2 globalRunSettings, string solutionRunSettingsFile) 
             : base(globalRunSettings)
         {
             _solutionRunSettingsFile = solutionRunSettingsFile;

--- a/GoogleTestAdapter/TestAdapter.Tests/Settings/RunSettingsServiceTests.cs
+++ b/GoogleTestAdapter/TestAdapter.Tests/Settings/RunSettingsServiceTests.cs
@@ -305,7 +305,7 @@ namespace GoogleTestAdapter.TestAdapter.Settings
                 TraitsRegexesBefore = "Global"
             };
 
-            var mockGlobalRunSettings = new Mock<IGlobalRunSettings>();
+            var mockGlobalRunSettings = new Mock<IGlobalRunSettings2>();
             mockGlobalRunSettings.Setup(grs => grs.RunSettings).Returns(globalRunSettings);
 
             return new RunSettingsServiceUnderTest(mockGlobalRunSettings.Object, solutionRunSettingsFile);
@@ -345,7 +345,7 @@ namespace GoogleTestAdapter.TestAdapter.Settings
             string userSolutionWorkingDir, string userProject1WorkingDir, string userProject3WorkingDir)
         {
             var globalSettings = new RunSettings { ProjectRegex = null, WorkingDir = GlobalWorkingDir };
-            var mockGlobalRunSettings = new Mock<IGlobalRunSettings>();
+            var mockGlobalRunSettings = new Mock<IGlobalRunSettings2>();
             mockGlobalRunSettings.Setup(grs => grs.RunSettings).Returns(globalSettings);
 
             var solutionSettingsContainer = SetupSettingsContainer(solutionSolutionWorkingDir, solutionProject1WorkingDir, solutionProject2WorkingDir, null);

--- a/GoogleTestAdapter/TestAdapter/Settings/GlobalRunSettingsProvider.cs
+++ b/GoogleTestAdapter/TestAdapter/Settings/GlobalRunSettingsProvider.cs
@@ -4,9 +4,9 @@ using GoogleTestAdapter.Settings;
 namespace GoogleTestAdapter.TestAdapter.Settings
 {
 
-    [Export(typeof(IGlobalRunSettings))]
-    [Export(typeof(IGlobalRunSettingsInternal))]
-    public class GlobalRunSettingsProvider : IGlobalRunSettingsInternal
+    [Export(typeof(IGlobalRunSettings2))]
+    [Export(typeof(IGlobalRunSettingsInternal2))]
+    public class GlobalRunSettingsProvider : IGlobalRunSettingsInternal2
     {
         public RunSettings RunSettings { get; set; } = new RunSettings();
     }

--- a/GoogleTestAdapter/TestAdapter/Settings/IGlobalRunSettings.cs
+++ b/GoogleTestAdapter/TestAdapter/Settings/IGlobalRunSettings.cs
@@ -3,7 +3,7 @@
 namespace GoogleTestAdapter.TestAdapter.Settings
 {
 
-    public interface IGlobalRunSettings
+    public interface IGlobalRunSettings2
     {
         RunSettings RunSettings { get; }
     }

--- a/GoogleTestAdapter/TestAdapter/Settings/IGlobalRunSettingsInternal.cs
+++ b/GoogleTestAdapter/TestAdapter/Settings/IGlobalRunSettingsInternal.cs
@@ -3,7 +3,7 @@
 namespace GoogleTestAdapter.TestAdapter.Settings
 {
 
-    public interface IGlobalRunSettingsInternal : IGlobalRunSettings
+    public interface IGlobalRunSettingsInternal2 : IGlobalRunSettings2
     {
         new RunSettings RunSettings { get; set; }
     }

--- a/GoogleTestAdapter/TestAdapter/Settings/RunSettingsService.cs
+++ b/GoogleTestAdapter/TestAdapter/Settings/RunSettingsService.cs
@@ -22,10 +22,10 @@ namespace GoogleTestAdapter.TestAdapter.Settings
     {
         public string Name => GoogleTestConstants.SettingsName;
 
-        private readonly IGlobalRunSettings _globalRunSettings;
+        private readonly IGlobalRunSettings2 _globalRunSettings;
 
         [ImportingConstructor]
-        public RunSettingsService([Import(typeof(IGlobalRunSettings))] IGlobalRunSettings globalRunSettings)
+        public RunSettingsService([Import(typeof(IGlobalRunSettings2))] IGlobalRunSettings2 globalRunSettings)
         {
             _globalRunSettings = globalRunSettings;
         }

--- a/GoogleTestAdapter/VsPackage.GTA/GoogleTestExtensionOptionsPage.cs
+++ b/GoogleTestAdapter/VsPackage.GTA/GoogleTestExtensionOptionsPage.cs
@@ -30,7 +30,7 @@ namespace GoogleTestAdapter.VsPackage
             if (!_isAsyncLoadSupported)
             {
                 var componentModel = (IComponentModel)GetGlobalService(typeof(SComponentModel));
-                _globalRunSettings = componentModel.GetService<IGlobalRunSettingsInternal>();
+                _globalRunSettings = componentModel.GetService<IGlobalRunSettingsInternal2>();
                 DoInitialize();
             }
         }
@@ -46,7 +46,7 @@ namespace GoogleTestAdapter.VsPackage
             return ThreadHelper.JoinableTaskFactory.RunAsync<object>(async () =>
             {
                 var componentModel = await serviceProvider.GetServiceAsync<IComponentModel>(typeof(SComponentModel));
-                _globalRunSettings = componentModel.GetService<IGlobalRunSettingsInternal>();
+                _globalRunSettings = componentModel.GetService<IGlobalRunSettingsInternal2>();
 
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/GoogleTestAdapter/VsPackage.Shared/GoogleTestExtensionOptionsPage.cs
+++ b/GoogleTestAdapter/VsPackage.Shared/GoogleTestExtensionOptionsPage.cs
@@ -29,7 +29,7 @@ namespace GoogleTestAdapter.VsPackage
     {
         private readonly string _debuggingNamedPipeId = Guid.NewGuid().ToString();
 
-        private IGlobalRunSettingsInternal _globalRunSettings;
+        private IGlobalRunSettingsInternal2 _globalRunSettings;
 
         private GeneralOptionsDialogPage _generalOptions;
         private ParallelizationOptionsDialogPage _parallelizationOptions;

--- a/GoogleTestAdapter/VsPackage.TAfGT/GoogleTestExtensionOptionsPage.cs
+++ b/GoogleTestAdapter/VsPackage.TAfGT/GoogleTestExtensionOptionsPage.cs
@@ -27,7 +27,7 @@ namespace GoogleTestAdapter.VsPackage
             await base.InitializeAsync(cancellationToken, progress);
 
             var componentModel = await GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
-            _globalRunSettings = componentModel.GetService<IGlobalRunSettingsInternal>();
+            _globalRunSettings = componentModel.GetService<IGlobalRunSettingsInternal2>();
 
             await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 


### PR DESCRIPTION
This was clashing on MEF import when both were installed. This removes the annoying error message for users.