### PR TITLE
Move new strings to accessible resx

### DIFF
--- a/GoogleTestAdapter/Common.Dynamic.TAfGT/Resources.resx
+++ b/GoogleTestAdapter/Common.Dynamic.TAfGT/Resources.resx
@@ -123,12 +123,6 @@
   <data name="ExtensionName" xml:space="preserve">
     <value>Test Adapter for Google Test</value>
   </data>
-  <data name="NewItemDescription" xml:space="preserve">
-    <value>A Google Test based unit test.</value>
-  </data>
-  <data name="NewProjectDescrption" xml:space="preserve">
-    <value>Write C++ unit tests using Google Test. Includes a copy of the Google Test library for use.</value>
-  </data>
   <data name="TestDiscoveryStarting" xml:space="preserve">
     <value>Test Adapter for Google Test: Test discovery starting...</value>
   </data>

--- a/GoogleTestAdapter/GoogleTestItemTemplate/GoogleTest.vstemplate
+++ b/GoogleTestAdapter/GoogleTestItemTemplate/GoogleTest.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
-    <Name>Google Test</Name>
+    <Name Package="{6e0d1c7a-ef6a-4442-b8ce-9a58b21c3239}" ID="115"/>
     <Description Package="{6e0d1c7a-ef6a-4442-b8ce-9a58b21c3239}" ID="113"/>
     <ProjectType>VC</ProjectType>
     <TemplateID>Microsoft.VisualC.Item.GoogleTest</TemplateID>

--- a/GoogleTestAdapter/GoogleTestItemTemplate/GoogleTest.vstemplate
+++ b/GoogleTestAdapter/GoogleTestItemTemplate/GoogleTest.vstemplate
@@ -1,7 +1,7 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
     <Name>Google Test</Name>
-    <Description>A Google Test based unit test.</Description>
+    <Description Package="{6e0d1c7a-ef6a-4442-b8ce-9a58b21c3239}" ID="113"/>
     <ProjectType>VC</ProjectType>
     <TemplateID>Microsoft.VisualC.Item.GoogleTest</TemplateID>
     <SortOrder>10</SortOrder>

--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vstemplate
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vstemplate
@@ -1,7 +1,7 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
     <Name>Google Test</Name>
-    <Description>Write C++ unit tests using Google Test. Includes a copy of the Google Test library for use.</Description>
+    <Description Package="{6e0d1c7a-ef6a-4442-b8ce-9a58b21c3239}" ID="114"/>
     <ProjectType>VC</ProjectType>
     <TemplateID>Microsoft.VisualC.Project.GoogleTest</TemplateID>
     <SortOrder>1000</SortOrder>

--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vstemplate
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Google Test</Name>
+    <Name Package="{6e0d1c7a-ef6a-4442-b8ce-9a58b21c3239}" ID="115"/>
     <Description Package="{6e0d1c7a-ef6a-4442-b8ce-9a58b21c3239}" ID="114"/>
     <ProjectType>VC</ProjectType>
     <TemplateID>Microsoft.VisualC.Project.GoogleTest</TemplateID>

--- a/GoogleTestAdapter/VsPackage.TAfGT/Resources/VSPackage.Designer.cs
+++ b/GoogleTestAdapter/VsPackage.TAfGT/Resources/VSPackage.Designer.cs
@@ -97,6 +97,15 @@ namespace GoogleTestAdapter.VsPackage.TAfGT.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Google Test.
+        /// </summary>
+        internal static string _115 {
+            get {
+                return ResourceManager.GetString("115", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
         /// </summary>
         internal static System.Drawing.Icon _400 {

--- a/GoogleTestAdapter/VsPackage.TAfGT/Resources/VSPackage.Designer.cs
+++ b/GoogleTestAdapter/VsPackage.TAfGT/Resources/VSPackage.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleTestAdapter.Common {
+namespace GoogleTestAdapter.VsPackage.TAfGT.Resources {
     using System;
     
     
@@ -22,24 +22,24 @@ namespace GoogleTestAdapter.Common {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class Resources {
+    internal class VSPackage {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources() {
+        internal VSPackage() {
         }
         
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Resources.ResourceManager ResourceManager {
+        internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("GoogleTestAdapter.Common.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("GoogleTestAdapter.VsPackage.TAfGT.Resources.VSPackage", typeof(VSPackage).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -51,7 +51,7 @@ namespace GoogleTestAdapter.Common {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Globalization.CultureInfo Culture {
+        internal static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -61,47 +61,75 @@ namespace GoogleTestAdapter.Common {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enables Visual Studio&apos;s testing tools with unit tests written for Google Test..
-        /// </summary>
-        public static string ExtensionDescription {
-            get {
-                return ResourceManager.GetString("ExtensionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Test Adapter for Google Test.
         /// </summary>
-        public static string ExtensionName {
+        internal static string _110 {
             get {
-                return ResourceManager.GetString("ExtensionName", resourceCulture);
+                return ResourceManager.GetString("110", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test Adapter for Google Test: Test discovery starting....
+        ///   Looks up a localized string similar to Enables Visual Studio&apos;s testing tools with unit tests written for Google Test.  The use terms and Third Party Notices are available in the extension installation directory..
         /// </summary>
-        public static string TestDiscoveryStarting {
+        internal static string _112 {
             get {
-                return ResourceManager.GetString("TestDiscoveryStarting", resourceCulture);
+                return ResourceManager.GetString("112", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test Adapter for Google Test: Test execution starting....
+        ///   Looks up a localized string similar to A Google Test based unit test..
         /// </summary>
-        public static string TestExecutionStarting {
+        internal static string _113 {
             get {
-                return ResourceManager.GetString("TestExecutionStarting", resourceCulture);
+                return ResourceManager.GetString("113", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}Check out Test Adapter for Google Test&apos;s trouble shooting section at https://go.microsoft.com/fwlink/?linkid=848168.
+        ///   Looks up a localized string similar to Write C++ unit tests using Google Test. Includes a copy of the Google Test library for use..
         /// </summary>
-        public static string TroubleShootingLink {
+        internal static string _114 {
             get {
-                return ResourceManager.GetString("TroubleShootingLink", resourceCulture);
+                return ResourceManager.GetString("114", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
+        /// </summary>
+        internal static System.Drawing.Icon _400 {
+            get {
+                object obj = ResourceManager.GetObject("400", resourceCulture);
+                return ((System.Drawing.Icon)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to General.
+        /// </summary>
+        internal static string _501 {
+            get {
+                return ResourceManager.GetString("501", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parallelization.
+        /// </summary>
+        internal static string _502 {
+            get {
+                return ResourceManager.GetString("502", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Google Test.
+        /// </summary>
+        internal static string _503 {
+            get {
+                return ResourceManager.GetString("503", resourceCulture);
             }
         }
     }

--- a/GoogleTestAdapter/VsPackage.TAfGT/Resources/VSPackage.resx
+++ b/GoogleTestAdapter/VsPackage.TAfGT/Resources/VSPackage.resx
@@ -123,6 +123,12 @@
   <data name="112" xml:space="preserve">
     <value>Enables Visual Studio's testing tools with unit tests written for Google Test.  The use terms and Third Party Notices are available in the extension installation directory.</value>
   </data>
+  <data name="113" xml:space="preserve">
+    <value>A Google Test based unit test.</value>
+  </data>
+  <data name="114" xml:space="preserve">
+    <value>Write C++ unit tests using Google Test. Includes a copy of the Google Test library for use.</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\Resources\Icons\Icon.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/GoogleTestAdapter/VsPackage.TAfGT/Resources/VSPackage.resx
+++ b/GoogleTestAdapter/VsPackage.TAfGT/Resources/VSPackage.resx
@@ -129,6 +129,9 @@
   <data name="114" xml:space="preserve">
     <value>Write C++ unit tests using Google Test. Includes a copy of the Google Test library for use.</value>
   </data>
+  <data name="115" xml:space="preserve">
+    <value>Google Test</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\Resources\Icons\Icon.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/GoogleTestAdapter/VsPackage.TAfGT/VsPackage.TAfGT.csproj
+++ b/GoogleTestAdapter/VsPackage.TAfGT/VsPackage.TAfGT.csproj
@@ -75,6 +75,11 @@
   <ItemGroup>
     <Compile Include="GoogleTestExtensionOptionsPage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Resources\VSPackage.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>VSPackage.resx</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Key.snk" />
@@ -92,6 +97,8 @@
       <MergeWithCTO>true</MergeWithCTO>
       <ManifestResourceName>VSPackage</ManifestResourceName>
       <SubType>Designer</SubType>
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>VSPackage.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The new strings need to be part of the vs package to be accessible to the templates. Also, make those resources generate localizable artefacts.