### PR TITLE
fix reference package in the templates

### DIFF
--- a/GoogleTestAdapter/GoogleTestItemTemplate/GoogleTest.vstemplate
+++ b/GoogleTestAdapter/GoogleTestItemTemplate/GoogleTest.vstemplate
@@ -1,7 +1,7 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
-    <Name Package="{6e0d1c7a-ef6a-4442-b8ce-9a58b21c3239}" ID="115"/>
-    <Description Package="{6e0d1c7a-ef6a-4442-b8ce-9a58b21c3239}" ID="113"/>
+    <Name Package="{6fac3232-df1d-400a-95ac-7daeaaee74ac}" ID="115"/>
+    <Description Package="{6fac3232-df1d-400a-95ac-7daeaaee74ac}" ID="113"/>
     <ProjectType>VC</ProjectType>
     <TemplateID>Microsoft.VisualC.Item.GoogleTest</TemplateID>
     <SortOrder>10</SortOrder>

--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vstemplate
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vstemplate
@@ -1,7 +1,7 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name Package="{6e0d1c7a-ef6a-4442-b8ce-9a58b21c3239}" ID="115"/>
-    <Description Package="{6e0d1c7a-ef6a-4442-b8ce-9a58b21c3239}" ID="114"/>
+    <Name Package="{6fac3232-df1d-400a-95ac-7daeaaee74ac}" ID="115"/>
+    <Description Package="{6fac3232-df1d-400a-95ac-7daeaaee74ac}" ID="114"/>
     <ProjectType>VC</ProjectType>
     <TemplateID>Microsoft.VisualC.Project.GoogleTest</TemplateID>
     <SortOrder>1000</SortOrder>


### PR DESCRIPTION
Was referencing the wrong project's package, messing with the resource strings. Validated this gets the right resources locally + localization now works for the templates as it should. 