### PR TITLE
Fix debugging from test explorer & don't attach to testhost.exe

### DIFF
--- a/GoogleTestAdapter/Packaging.TAfGT/Packaging.TAfGT.csproj
+++ b/GoogleTestAdapter/Packaging.TAfGT/Packaging.TAfGT.csproj
@@ -25,7 +25,7 @@
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
     <BypassVsixValidation>true</BypassVsixValidation>
-    <DeployExtension Condition="'$(TestAdapterFlavor)' != 'TAfGT'">false</DeployExtension>
+    <DeployExtension>false</DeployExtension>
     <IsProductComponent Condition="'$(ProductComponent)' == 'true'">true</IsProductComponent>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/GoogleTestAdapter/Packaging.TAfGT/source.extension.vsixmanifest
+++ b/GoogleTestAdapter/Packaging.TAfGT/source.extension.vsixmanifest
@@ -33,6 +33,7 @@
         <Asset Type="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.3.nupkg" d:Source="File" Path="Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.3.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="GoogleTestProjectTemplate" d:TargetPath="|GoogleTestProjectTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="GoogleTestItemTemplate" d:TargetPath="|GoogleTestItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="VsPackage.TAfGT" Path="|VsPackage.TAfGT|" />
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.8.27729.1,17.0)" DisplayName="Visual Studio core editor" />

--- a/GoogleTestAdapter/TestAdapter.Tests/TestAdapter.Tests.csproj
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestAdapter.Tests.csproj
@@ -52,15 +52,15 @@
       <HintPath>$(NuGetPackages)FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
-      <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=16.10.0-release-20210330-02, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
+      <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.16.10.0-release-20210330-02\lib\net45\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'GTA'">
       <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
-      <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=16.10.0-release-20210330-02, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
+      <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.16.10.0-release-20210330-02\lib\net45\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq, Version=4.5.30.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">

--- a/GoogleTestAdapter/TestAdapter.Tests/packages.config.tt
+++ b/GoogleTestAdapter/TestAdapter.Tests/packages.config.tt
@@ -9,7 +9,7 @@
 <# if (TestAdapterFlavor == "GTA") { #>
   <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net452" />
 <# } else if (TestAdapterFlavor == "TAfGT") { #>
-  <package id="Microsoft.TestPlatform.ObjectModel" version="15.0.0" targetFramework="net46" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.10.0-release-20210330-02" targetFramework="net46" />
 <# } #>
   <package id="OpenCover" version="4.7.922" targetFramework="net452" />
 </packages>

--- a/GoogleTestAdapter/TestAdapter/TestAdapter.csproj
+++ b/GoogleTestAdapter/TestAdapter/TestAdapter.csproj
@@ -144,6 +144,14 @@
       <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.16.10.0-release-20210330-02\lib\net45\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
+	<Reference Include="Microsoft.VisualStudio.TestWindow.Interfaces, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'GTA'">
+      <HintPath>$(NuGetPackages)Microsoft.VisualStudio.TestWindow.Interfaces.11.0.61030\lib\net45\Microsoft.VisualStudio.TestWindow.Interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestWindow.Interfaces, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
+      <HintPath>$(NuGetPackages)Microsoft.VisualStudio.TestWindow.Interfaces.11.0.61030\lib\net45\Microsoft.VisualStudio.TestWindow.Interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath Condition="'$(TestAdapterFlavor)' == 'GTA'">$(NuGetPackages)VSSDK.TextManager.Interop.7.0.4\lib\net20\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
       <Private>True</Private>

--- a/GoogleTestAdapter/TestAdapter/TestAdapter.csproj
+++ b/GoogleTestAdapter/TestAdapter/TestAdapter.csproj
@@ -144,14 +144,6 @@
       <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.16.10.0-release-20210330-02\lib\net45\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
-	<Reference Include="Microsoft.VisualStudio.TestWindow.Interfaces, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'GTA'">
-      <HintPath>$(NuGetPackages)Microsoft.VisualStudio.TestWindow.Interfaces.11.0.61030\lib\net45\Microsoft.VisualStudio.TestWindow.Interfaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestWindow.Interfaces, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
-      <HintPath>$(NuGetPackages)Microsoft.VisualStudio.TestWindow.Interfaces.11.0.61030\lib\net45\Microsoft.VisualStudio.TestWindow.Interfaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath Condition="'$(TestAdapterFlavor)' == 'GTA'">$(NuGetPackages)VSSDK.TextManager.Interop.7.0.4\lib\net20\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
       <Private>True</Private>

--- a/GoogleTestAdapter/TestAdapter/TestAdapter.csproj
+++ b/GoogleTestAdapter/TestAdapter/TestAdapter.csproj
@@ -133,15 +133,15 @@
       <Private>True</Private>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
-      <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=16.10.0-release-20210330-02, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
+      <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.16.10.0-release-20210330-02\lib\net45\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'GTA'">
       <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=16.10.0-release-20210330-02, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
-      <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.16.10.0-release-20210330-02\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.16.10.0-release-20210330-02\lib\net45\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/GoogleTestAdapter/TestAdapter/TestAdapter.csproj
+++ b/GoogleTestAdapter/TestAdapter/TestAdapter.csproj
@@ -140,8 +140,8 @@
       <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
-      <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=16.10.0-release-20210330-02, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(TestAdapterFlavor)' == 'TAfGT'">
+      <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.16.10.0-release-20210330-02\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -15,7 +15,6 @@ using GoogleTestAdapter.Settings;
 using GoogleTestAdapter.Model;
 using GoogleTestAdapter.TestAdapter.Helpers;
 using GoogleTestAdapter.TestAdapter.Framework;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace GoogleTestAdapter.TestAdapter
 {

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -15,12 +15,13 @@ using GoogleTestAdapter.Settings;
 using GoogleTestAdapter.Model;
 using GoogleTestAdapter.TestAdapter.Helpers;
 using GoogleTestAdapter.TestAdapter.Framework;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace GoogleTestAdapter.TestAdapter
 {
 
     [ExtensionUri(ExecutorUriString)]
-    public partial class TestExecutor : ITestExecutor
+    public partial class TestExecutor : ITestExecutor2
     {
         public static readonly Uri ExecutorUri = new Uri(ExecutorUriString);
 
@@ -234,6 +235,17 @@ namespace GoogleTestAdapter.TestAdapter
             reporter.AllTestsFinished();
         }
 
+        public bool ShouldAttachToTestHost(IEnumerable<string> sources, IRunContext runContext)
+        {
+            // TODO: expose setting in runContext to attach to testhost if needed?
+            return false;
+        }
+
+        public bool ShouldAttachToTestHost(IEnumerable<VsTestCase> tests, IRunContext runContext)
+        {
+            // TODO: expose setting in runContext to attach to testhost if needed?
+            return false;
+        }
     }
 
 }

--- a/GoogleTestAdapter/TestAdapter/packages.config.tt
+++ b/GoogleTestAdapter/TestAdapter/packages.config.tt
@@ -28,9 +28,7 @@
   <package id="VSSDK.TextManager.Interop.10" version="10.0.4" targetFramework="net45" />
   <package id="VSSDK.TextManager.Interop.8" version="8.0.4" targetFramework="net45" />
   <package id="VSSDK.TextManager.Interop.9" version="9.0.4" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.TestWindow.Interfaces" version="11.0.61030" targetFramework="net452" />
 <# } else if (TestAdapterFlavor == "TAfGT") { #>
   <package id="Microsoft.TestPlatform.ObjectModel" version="16.10.0-release-20210330-02" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.TestWindow.Interfaces" version="11.0.61030" targetFramework="net46" />
 <# } #>
 </packages>

--- a/GoogleTestAdapter/TestAdapter/packages.config.tt
+++ b/GoogleTestAdapter/TestAdapter/packages.config.tt
@@ -28,7 +28,9 @@
   <package id="VSSDK.TextManager.Interop.10" version="10.0.4" targetFramework="net45" />
   <package id="VSSDK.TextManager.Interop.8" version="8.0.4" targetFramework="net45" />
   <package id="VSSDK.TextManager.Interop.9" version="9.0.4" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.TestWindow.Interfaces" version="11.0.61030" targetFramework="net452" />
 <# } else if (TestAdapterFlavor == "TAfGT") { #>
   <package id="Microsoft.TestPlatform.ObjectModel" version="16.10.0-release-20210330-02" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.TestWindow.Interfaces" version="11.0.61030" targetFramework="net46" />
 <# } #>
 </packages>

--- a/GoogleTestAdapter/TestAdapter/packages.config.tt
+++ b/GoogleTestAdapter/TestAdapter/packages.config.tt
@@ -29,6 +29,6 @@
   <package id="VSSDK.TextManager.Interop.8" version="8.0.4" targetFramework="net45" />
   <package id="VSSDK.TextManager.Interop.9" version="9.0.4" targetFramework="net45" />
 <# } else if (TestAdapterFlavor == "TAfGT") { #>
-  <package id="Microsoft.TestPlatform.ObjectModel" version="15.0.0" targetFramework="net46" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.10.0-release-20210330-02" targetFramework="net46" />
 <# } #>
 </packages>


### PR DESCRIPTION
Right now there is no option to attach to testhost.exe if wanted, as there does not seem to be any value in that as per the bug. This also includes a fix to make sure we don't try to deploy the vsix when building which breaks the CI build now since moving to the new resource pool.