### PR TITLE
Add localized descriptions to vsixlangpack

### DIFF
--- a/GoogleTestAdapter/Packaging.TAfGT/cs/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/cs/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Testovací adaptér pro Google Test</DisplayName>
-    <Description></Description>
+    <Description>Povolí v testovacích nástrojích sady Visual Studio testy jednotek vytvořené na bázi knihovny Google Test.</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/de/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/de/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Testadapter für Google Test</DisplayName>
-    <Description></Description>
+    <Description>Ermöglicht die Verwendung von Visual Studio-Testtools mit Komponententests, die für Google Test geschrieben wurden.</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/es/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/es/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Test Adapter para Google Test</DisplayName>
-    <Description></Description>
+    <Description>Habilita las herramientas de pruebas de Visual Studio con las pruebas unitarias escritas para Google Test.</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/fr/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/fr/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Adaptateur de test pour Google Test</DisplayName>
-    <Description></Description>
+    <Description>Active les outils de test de Visual Studio avec les tests unitaires écrits pour Google Test.</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/it/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/it/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Test Adapter for Google Test</DisplayName>
-    <Description></Description>
+    <Description>Abilita gli strumenti di test di Visual Studio con unit test scritti per Google Test.</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/ja/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/ja/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Test Adapter for Google Test</DisplayName>
-    <Description></Description>
+    <Description>Google Test 向けに作成された単体テストによる、Visual Studio のテスト ツールを有効にします。</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/ko/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/ko/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Test Adapter for Google Test</DisplayName>
-    <Description></Description>
+    <Description>Google Test용으로 작성된 단위 테스트와 함께 Visual Studio의 테스트 도구를 사용합니다.</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/pl/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/pl/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Test Adapter for Google Test</DisplayName>
-    <Description></Description>
+    <Description>Udostępnia w narzędziach do testowania w programie Visual Studio testy jednostkowe napisane dla platformy Google Test.</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/pt-BR/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/pt-BR/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Adaptador de Teste para o Google Test</DisplayName>
-    <Description></Description>
+    <Description>Habilita as ferramentas de teste do Visual Studio com testes de unidade gravados para o Google Test.</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/ru/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/ru/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Адаптер теста для Google Test</DisplayName>
-    <Description></Description>
+    <Description>Включает средства тестирования Visual Studio с модульными тестами, созданными для Google Test.</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/tr/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/tr/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>Google Test için Test Bağdaştırıcısı</DisplayName>
-    <Description></Description>
+    <Description>Google Test için yazılmış birim testleriyle Visual Studio test araçlarını etkinleştirir.</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/zh-Hans/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/zh-Hans/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>适用于 Google Test 的测试适配器</DisplayName>
-    <Description></Description>
+    <Description>启用带有针对 Google Test 编写的单元测试的 Visual Studio 测试工具。</Description>
   </Metadata>
 </PackageLanguagePackManifest>

--- a/GoogleTestAdapter/Packaging.TAfGT/zh-Hant/Extension.vsixlangpack
+++ b/GoogleTestAdapter/Packaging.TAfGT/zh-Hant/Extension.vsixlangpack
@@ -2,6 +2,6 @@
 <PackageLanguagePackManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
     <DisplayName>適用於 Google Test 的測試配接器</DisplayName>
-    <Description></Description>
+    <Description>利用為 Google Test 所撰寫的單元測試來啟用 Visual Studio 的測試工具。</Description>
   </Metadata>
 </PackageLanguagePackManifest>


### PR DESCRIPTION
Noticed during validation of the last loc bug that the descriptions weren't localized. We had gotten the strings, but never applied them here.