### PR TITLE
Update microbuild core reference and vsmanproj for sbom insertion

### DIFF
--- a/GoogleTestAdapter/Common.Dynamic.GTA/Common.Dynamic.GTA.csproj
+++ b/GoogleTestAdapter/Common.Dynamic.GTA/Common.Dynamic.GTA.csproj
@@ -62,7 +62,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+      <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestAdapter/Common.Dynamic.TAfGT/Common.Dynamic.TAfGT.csproj
+++ b/GoogleTestAdapter/Common.Dynamic.TAfGT/Common.Dynamic.TAfGT.csproj
@@ -79,7 +79,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestAdapter/Common/Common.csproj
+++ b/GoogleTestAdapter/Common/Common.csproj
@@ -62,7 +62,7 @@
     <None Include="Key.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestAdapter/Core/Core.csproj
+++ b/GoogleTestAdapter/Core/Core.csproj
@@ -134,7 +134,7 @@
     <Content Include="Resources\GTA_Traits_1.7.0.h" />
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+      <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestAdapter/DiaResolver/DiaResolver.csproj
+++ b/GoogleTestAdapter/DiaResolver/DiaResolver.csproj
@@ -107,7 +107,7 @@
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestAdapter/NewProjectWizard/NewProjectWizard.csproj
+++ b/GoogleTestAdapter/NewProjectWizard/NewProjectWizard.csproj
@@ -56,7 +56,7 @@
     </SignFilesDependsOn>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestAdapter/Packaging.GTA/Packaging.GTA.csproj
+++ b/GoogleTestAdapter/Packaging.GTA/Packaging.GTA.csproj
@@ -85,7 +85,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestAdapter/Packaging.TAfGT/Packaging.TAfGT.csproj
+++ b/GoogleTestAdapter/Packaging.TAfGT/Packaging.TAfGT.csproj
@@ -118,7 +118,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestAdapter/TestAdapter/TestAdapter.csproj
+++ b/GoogleTestAdapter/TestAdapter/TestAdapter.csproj
@@ -57,7 +57,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.10.0-release-20210330-02" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-2-31221-277" />
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestAdapter/VsPackage.GTA/VsPackage.GTA.csproj
+++ b/GoogleTestAdapter/VsPackage.GTA/VsPackage.GTA.csproj
@@ -137,7 +137,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommonMark.NET" Version="0.15.1" />
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestAdapter/VsPackage.TAfGT/VsPackage.TAfGT.csproj
+++ b/GoogleTestAdapter/VsPackage.TAfGT/VsPackage.TAfGT.csproj
@@ -113,7 +113,7 @@
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.CSharp" />
 
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -128,7 +128,7 @@ function Add-Signing {
     $xml = [xml](Get-Content "$Directory\$ProjectName.vcxproj")
     $ProjectNameDebug = -join("$ProjectName", "d")
 
-    $microbuild = "$Env:USERPROFILE\.nuget\packages\microsoft.visualstudioeng.microbuild.core\0.4.1"
+    $microbuild = "$Env:USERPROFILE\.nuget\packages\microsoft.visualstudioeng.microbuild.core\1.0.0"
 
     $MicroBuildProps = $xml.CreateElement("Import", "http://schemas.microsoft.com/developer/msbuild/2003")
     $MicroBuildProps.SetAttribute("Project", "$microbuild\build\Microsoft.VisualStudioEng.MicroBuild.Core.props")

--- a/GoogleTestNuGet/googletest.SignNuGet.proj
+++ b/GoogleTestNuGet/googletest.SignNuGet.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  <Import Project="$(MSBuildThisFileDirectory)\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" />
   <PropertyGroup>
     <ProjectGuid>{9C5FB75F-BE2A-4358-A2C8-E950EB2A027A}</ProjectGuid>
     <TargetFrameworkVersion>$(FlavoredTargetFrameworkVersion)</TargetFrameworkVersion>
@@ -18,5 +18,5 @@
     </FilesToSign>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" />
 </Project>

--- a/GoogleTestNuGet/packages.config
+++ b/GoogleTestNuGet/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
@@ -11,11 +11,13 @@
   </PropertyGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
-  <Import Project="$(NuGetPackages)Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" />
+  <Import Project="$(NuGetPackages)Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" />
   
   <ItemGroup>
-    <MergeManifest Include="$(OutputPath)\..\Packaging.TAfGT\Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.json" />
+    <MergeManifest Include="$(OutputPath)\..\Packaging.TAfGT\Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.json"
+                   SBOMFileLocation="$(ArtifactsDir)\drop\_manifest\spdx_2.2\manifest.spdx.json"
+                   SBOMFileDestPath="$(ArtifactsDir)\drop" />
   </ItemGroup>
 
-  <Import Project="$(NuGetPackages)Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" /> 
+  <Import Project="$(NuGetPackages)Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" /> 
 </Project> 

--- a/swix/packages.config
+++ b/swix/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" targetFramework="net46" developmentDependency="true" />
   <package id="Nerdbank.GitVersioning" version="1.4.30" targetFramework="net46" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Update to version 1.0.0 which is required for the new sbom tools