### PR TITLE
Remove googletest submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ThirdParty/googletest"]
-	path = ThirdParty/googletest
-	url = https://github.com/google/googletest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ThirdParty/googletest"]
-	path = ThirdParty/googletest
-	url = https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/googletest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ThirdParty/googletest"]
+	path = ThirdParty/googletest
+	url = https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/googletest


### PR DESCRIPTION
Removing the reference to the external googletest submodule. To build this locally in the future, users will need to obtain their own copy of googletest sources and put them in the ThirdParty/googletest folder.