### PR TITLE
Change VsVersion Logging from Error to Info

### DIFF
--- a/GoogleTestAdapter/TestAdapter/Framework/VsVersion.cs
+++ b/GoogleTestAdapter/TestAdapter/Framework/VsVersion.cs
@@ -70,7 +70,7 @@ namespace GoogleTestAdapter.TestAdapter.Framework
                 }
                 catch (Exception e)
                 {
-                    logger?.LogError(String.Format(Resources.VSVersionMessage, e.Message));
+                    logger?.LogInfo(String.Format(Resources.VSVersionMessage, e.Message));
                     _version = VsVersion.Unknown;
                 }
                 return _version.Value;


### PR DESCRIPTION
Change unable to get version to info from error since it doesn't effect test discovery or execution.