### PR TITLE
Update test matching regex to include "number letters"

### DIFF
--- a/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
+++ b/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
@@ -8,8 +8,10 @@ namespace GoogleTestAdapter.TestCases
 
     public class StreamingListTestsParser
     {
-        private static readonly Regex SuiteRegex = new Regex($@"([\w\/]*(?:\.[\w\/]+)*)(?:{Regex.Escape(GoogleTestConstants.TypedTestMarker)}(.*))?", RegexOptions.Compiled);
-        private static readonly Regex NameRegex = new Regex($@"([\w\/]*)(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
+        private static readonly string SuiteInitialRegex = @"([\w\/\p{Nl}]*(?:\.[\w\/\p{Nl}]+)*)";
+        private static readonly string NameInitialRegex = @"([\w\/\p{Nl}]*)";
+        private static readonly Regex SuiteRegex = new Regex($@"{SuiteInitialRegex}(?:{Regex.Escape(GoogleTestConstants.TypedTestMarker)}(.*))?", RegexOptions.Compiled);
+        private static readonly Regex NameRegex = new Regex($@"{NameInitialRegex}(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
         private static readonly Regex IsParamRegex = new Regex(@"(\w+/)?\w+/\d+", RegexOptions.Compiled);
 
         private readonly string _testNameSeparator;


### PR DESCRIPTION
Some Unicode characters that are expected to work in test/suite names weren't showing up due to the way .Net regex works. "/w" ignores "number letters" so we need to add them to the regex explicitly with "/p{Nl}"