### PR TITLE
Make regex even more permissive for additional localization cases

### DIFF
--- a/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
+++ b/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
@@ -8,10 +8,8 @@ namespace GoogleTestAdapter.TestCases
 
     public class StreamingListTestsParser
     {
-        private static readonly string SuiteInitialRegex = @"([\w\/\p{Nl}]*(?:\.[\w\/\p{Nl}]+)*)";
-        private static readonly string NameInitialRegex = @"([\w\/\p{Nl}]*)";
-        private static readonly Regex SuiteRegex = new Regex($@"{SuiteInitialRegex}(?:{Regex.Escape(GoogleTestConstants.TypedTestMarker)}(.*))?", RegexOptions.Compiled);
-        private static readonly Regex NameRegex = new Regex($@"{NameInitialRegex}(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
+        private static readonly Regex SuiteRegex = new Regex($@"([\S\/]*(?:\.[\S\/]+)*)(?:{Regex.Escape(GoogleTestConstants.TypedTestMarker)}(.*))?", RegexOptions.Compiled);
+        private static readonly Regex NameRegex = new Regex($@"([\S\/]*)(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
         private static readonly Regex IsParamRegex = new Regex(@"(\w+/)?\w+/\d+", RegexOptions.Compiled);
 
         private readonly string _testNameSeparator;


### PR DESCRIPTION
The localization team got back to us with more cases that we didn't handle. This makes it much more permissive so that we'll catch all cases that googletest itself renders going forward. This also fixes non-localized test cases containing symbols that we didn't work with before, but googletest supports.