### PR TITLE
Remove unneeded MEF component

### DIFF
--- a/GoogleTestAdapter/Packaging.TAfGT/source.extension.vsixmanifest
+++ b/GoogleTestAdapter/Packaging.TAfGT/source.extension.vsixmanifest
@@ -33,7 +33,6 @@
         <Asset Type="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.6.nupkg" d:Source="File" Path="Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.6.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="GoogleTestProjectTemplate" d:TargetPath="|GoogleTestProjectTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="GoogleTestItemTemplate" d:TargetPath="|GoogleTestItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="VsPackage.TAfGT" Path="|VsPackage.TAfGT|" />
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.8.27729.1,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
This dll does not contain any MEF components and was wasting machine resources during MEF cache creation.