### PR TITLE
Dont include System.Memory.dll in vsix

### DIFF
--- a/GoogleTestAdapter/Packaging.TAfGT/Packaging.TAfGT.csproj
+++ b/GoogleTestAdapter/Packaging.TAfGT/Packaging.TAfGT.csproj
@@ -192,6 +192,7 @@
     <SuppressFromVsix Include="MessagePack.Annotations.dll" />
     <SuppressFromVsix Include="MessagePack.dll" />
     <SuppressFromVsix Include="Microsoft.VisualStudio.Interop.dll" />
+    <SuppressFromVsix Include="System.Memory.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />


### PR DESCRIPTION
This dll can mess with other test adapters looking to use the same library. Instead we can defer to the one shipped in VS.