### PR TITLE
Add back mef export that was removed

### DIFF
--- a/GoogleTestAdapter/Packaging.TAfGT/source.extension.vsixmanifest
+++ b/GoogleTestAdapter/Packaging.TAfGT/source.extension.vsixmanifest
@@ -33,6 +33,7 @@
         <Asset Type="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.6.nupkg" d:Source="File" Path="Packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.6.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="GoogleTestProjectTemplate" d:TargetPath="|GoogleTestProjectTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="GoogleTestItemTemplate" d:TargetPath="|GoogleTestItemTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="VsPackage.TAfGT" Path="|VsPackage.TAfGT|" />
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.8.27729.1,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
Revert of https://github.com/microsoft/TestAdapterForGoogleTest/pull/209

Turns out we do have a necessary MEF export in that project. We're exporting the IRunSettingsService to pass the settings through to the test host which eventually runs the tests.