### PR TITLE
Remove temp test file generation and parsing 

### DIFF
--- a/GoogleTestAdapter/Core.Tests/Runners/CommandLineGeneratorTests.cs
+++ b/GoogleTestAdapter/Core.Tests/Runners/CommandLineGeneratorTests.cs
@@ -26,8 +26,7 @@ namespace GoogleTestAdapter.Runners
             Action a =
                 () =>
                     // ReSharper disable once ObjectCreationAsStatement
-                    new CommandLineGenerator(new List<Model.TestCase>(), 0, null, "",
-                        TestEnvironment.Options);
+                    new CommandLineGenerator(new List<Model.TestCase>(), 0, null, TestEnvironment.Options);
             a.Should().Throw<ArgumentNullException>();
         }
 
@@ -37,7 +36,7 @@ namespace GoogleTestAdapter.Runners
         {
             string userParameters = "-testdirectory=\"MyTestDirectory\"";
 
-            string commandLine = new CommandLineGenerator(new List<Model.TestCase>(), TestDataCreator.DummyExecutable.Length, userParameters, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(new List<Model.TestCase>(), TestDataCreator.DummyExecutable.Length, userParameters, TestEnvironment.Options).GetCommandLines().First().CommandLine;
 
             commandLine.Should().EndWith(" -testdirectory=\"MyTestDirectory\"");
         }
@@ -47,7 +46,7 @@ namespace GoogleTestAdapter.Runners
         public void GetCommandLines_AllTests_ProducesCorrectArguments()
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1 param", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
 
             commandLine.Should().Be($"--gtest_output=\"xml:\"{DefaultArgs}");
         }
@@ -57,13 +56,13 @@ namespace GoogleTestAdapter.Runners
         public void GetCommandLines_CatchExceptionsOption_IsAppendedCorrectly()
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
             string catchExceptionsOption = GoogleTestConstants.GetCatchExceptionsOption(true);
             commandLine.Should().Contain(catchExceptionsOption);
 
             MockOptions.Setup(o => o.CatchExceptions).Returns(false);
 
-            commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
             catchExceptionsOption = GoogleTestConstants.GetCatchExceptionsOption(false);
 
             commandLine.Should().Contain(catchExceptionsOption);
@@ -74,13 +73,13 @@ namespace GoogleTestAdapter.Runners
         public void GetCommandLines_BreakOnFailureOption_IsAppendedCorrectly()
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
             string breakOnFailureOption = GoogleTestConstants.GetBreakOnFailureOption(false);
             commandLine.Should().Contain(breakOnFailureOption);
 
             MockOptions.Setup(o => o.BreakOnFailure).Returns(true);
 
-            commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
             breakOnFailureOption = GoogleTestConstants.GetBreakOnFailureOption(true);
             commandLine.Should().Contain(breakOnFailureOption);
         }
@@ -92,7 +91,7 @@ namespace GoogleTestAdapter.Runners
             MockOptions.Setup(o => o.NrOfTestRepetitions).Returns(4711);
 
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
 
             string repetitionsOption = GoogleTestConstants.NrOfRepetitionsOption + "=4711";
             commandLine.Should().Be($"--gtest_output=\"xml:\"{DefaultArgs}{repetitionsOption}");
@@ -105,7 +104,7 @@ namespace GoogleTestAdapter.Runners
             MockOptions.Setup(o => o.ShuffleTests).Returns(true);
 
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
 
             commandLine.Should().Be($"--gtest_output=\"xml:\"{DefaultArgs}{GoogleTestConstants.ShuffleTestsOption}");
         }
@@ -118,7 +117,7 @@ namespace GoogleTestAdapter.Runners
             MockOptions.Setup(o => o.ShuffleTestsSeed).Returns(4711);
 
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
 
             string shuffleTestsOption = GoogleTestConstants.ShuffleTestsOption
                 + GoogleTestConstants.ShuffleTestsSeedOption + "=4711";
@@ -133,7 +132,7 @@ namespace GoogleTestAdapter.Runners
             string[] allTestCaseNames = testCaseNamesWithCommonSuite.Union("BarSuite.FooTest".Yield()).ToArray();
             IEnumerable<Model.TestCase> testCasesWithCommonSuite = TestDataCreator.CreateDummyTestCasesFull(testCaseNamesWithCommonSuite, allTestCaseNames);
 
-            string commandLine = new CommandLineGenerator(testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLine = new CommandLineGenerator(testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
 
             commandLine.Should().Be($"--gtest_output=\"xml:\"{DefaultArgs} --gtest_filter=FooSuite.*:");
@@ -154,7 +153,7 @@ namespace GoogleTestAdapter.Runners
                 .ToArray();
             IEnumerable<Model.TestCase> testCasesWithCommonSuite = TestDataCreator.CreateDummyTestCasesFull(testCaseNamesWithCommonSuite, allTestCaseNames);
 
-            string commandLine = new CommandLineGenerator(testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLine = new CommandLineGenerator(testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
 
             commandLine.Should()
@@ -173,9 +172,9 @@ namespace GoogleTestAdapter.Runners
 
             IEnumerable<Model.TestCase> testCasesReversed = testCasesWithCommonSuite.Reverse();
 
-            string commandLine = new CommandLineGenerator(testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLine = new CommandLineGenerator(testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
-            string commandLineFromBackwards = new CommandLineGenerator(testCasesReversed, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLineFromBackwards = new CommandLineGenerator(testCasesReversed, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
 
             string expectedCommandLine = $"--gtest_output=\"xml:\"{DefaultArgs} --gtest_filter=FooSuite.*:";
@@ -191,7 +190,7 @@ namespace GoogleTestAdapter.Runners
             string[] allTestCaseNames = testCaseNamesWithDifferentSuite.Union(new[]{ "FooSuite.BazTest", "BarSuite.BazTest2" }).ToArray();
             IEnumerable<Model.TestCase> testCasesWithDifferentSuite = TestDataCreator.CreateDummyTestCasesFull(testCaseNamesWithDifferentSuite, allTestCaseNames);
 
-            string commandLine = new CommandLineGenerator(testCasesWithDifferentSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLine = new CommandLineGenerator(testCasesWithDifferentSuite, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
 
             commandLine.Should()
@@ -206,7 +205,7 @@ namespace GoogleTestAdapter.Runners
             string[] allTestCaseNames = testCaseNamesWithDifferentSuite.Union(new[] { "FooSuite.BazTest", "BarSuite.BazTest2" }).ToArray();
             IEnumerable<Model.TestCase> testCasesWithDifferentSuite = TestDataCreator.CreateDummyTestCasesFull(testCaseNamesWithDifferentSuite, allTestCaseNames);
 
-            string commandLine = new CommandLineGenerator(testCasesWithDifferentSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLine = new CommandLineGenerator(testCasesWithDifferentSuite, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
 
             commandLine.Should()
@@ -230,7 +229,7 @@ namespace GoogleTestAdapter.Runners
             }
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCasesFull(testsToExecute.ToArray(), allTests.ToArray());
 
-            List<CommandLineGenerator.Args> commands = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            List<CommandLineGenerator.Args> commands = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options)
                 .GetCommandLines().ToList();
 
             commands.Count.Should().Be(3);
@@ -277,7 +276,7 @@ namespace GoogleTestAdapter.Runners
 
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCasesFull(testsToExecute.ToArray(), allTests.ToArray());
 
-            List<CommandLineGenerator.Args> commands = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            List<CommandLineGenerator.Args> commands = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", TestEnvironment.Options)
                 .GetCommandLines().ToList();
 
             commands.Count.Should().Be(3);

--- a/GoogleTestAdapter/Core/GoogleTestConstants.cs
+++ b/GoogleTestAdapter/Core/GoogleTestConstants.cs
@@ -44,11 +44,6 @@ namespace GoogleTestAdapter
             ListTestsOption
         };
 
-        public static string GetResultXmlFileOption(string resultXmlFile)
-        {
-            return "--gtest_output=\"xml:" + resultXmlFile + "\"";
-        }
-
         public static string GetCatchExceptionsOption(bool catchThem)
         {
             int optionValue = catchThem ? 1 : 0;

--- a/GoogleTestAdapter/Core/Runners/CommandLineGenerator.cs
+++ b/GoogleTestAdapter/Core/Runners/CommandLineGenerator.cs
@@ -29,27 +29,24 @@ namespace GoogleTestAdapter.Runners
 
         private readonly int _lengthOfExecutableString;
         private readonly IList<TestCase> _testCasesToRun;
-        private readonly string _resultXmlFile;
         private readonly SettingsWrapper _settings;
         private readonly string _userParameters;
 
         public CommandLineGenerator(IEnumerable<TestCase> testCasesToRun,
-            int lengthOfExecutableString, string userParameters, string resultXmlFile,
-            SettingsWrapper settings)
+            int lengthOfExecutableString, string userParameters, SettingsWrapper settings)
         {
             if (userParameters == null)
                 throw new ArgumentNullException(nameof(userParameters));
 
             _lengthOfExecutableString = lengthOfExecutableString;
             _testCasesToRun = testCasesToRun.ToList();
-            _resultXmlFile = resultXmlFile;
             _settings = settings;
             _userParameters = userParameters;
         }
 
         public IEnumerable<Args> GetCommandLines()
         {
-            string baseCommandLine = GetOutputpathParameter();
+            string baseCommandLine = string.Empty;
             baseCommandLine += GetCatchExceptionsParameter();
             baseCommandLine += GetBreakOnFailureParameter();
             baseCommandLine += GetAlsoRunDisabledTestsParameter();
@@ -138,11 +135,6 @@ namespace GoogleTestAdapter.Runners
         private string GetAdditionalUserParameter()
         {
             return _userParameters.Length == 0 ? "" : " " + _userParameters;
-        }
-
-        private string GetOutputpathParameter()
-        {
-            return GoogleTestConstants.GetResultXmlFileOption(_resultXmlFile);
         }
 
         private string GetCatchExceptionsParameter()

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -116,10 +116,9 @@ namespace GoogleTestAdapter.Runners
             IEnumerable<TestCase> testCasesToRun, string userParameters,
             bool isBeingDebugged, IDebuggedProcessLauncher debuggedLauncher, IProcessExecutor executor)
         {
-            string resultXmlFile = Path.GetTempFileName();
             var serializer = new TestDurationSerializer();
 
-            var generator = new CommandLineGenerator(testCasesToRun, executable.Length, userParameters, resultXmlFile, _settings);
+            var generator = new CommandLineGenerator(testCasesToRun, executable.Length, userParameters, _settings);
             foreach (CommandLineGenerator.Args arguments in generator.GetCommandLines())
             {
                 if (_canceled)
@@ -127,7 +126,7 @@ namespace GoogleTestAdapter.Runners
                     break;
                 }
                 var streamingParser = new StreamingStandardOutputTestResultParser(arguments.TestCases, _logger, _frameworkReporter);
-                var results = RunTests(executable, workingDir, envVars, isBeingDebugged, debuggedLauncher, arguments, resultXmlFile, executor, streamingParser).ToArray();
+                var results = RunTests(executable, workingDir, envVars, isBeingDebugged, debuggedLauncher, arguments, executor, streamingParser).ToArray();
 
                 try
                 {
@@ -154,11 +153,11 @@ namespace GoogleTestAdapter.Runners
         }
 
         private IEnumerable<TestResult> RunTests(string executable, string workingDir, IDictionary<string, string> envVars, bool isBeingDebugged,
-            IDebuggedProcessLauncher debuggedLauncher, CommandLineGenerator.Args arguments, string resultXmlFile, IProcessExecutor executor, StreamingStandardOutputTestResultParser streamingParser)
+            IDebuggedProcessLauncher debuggedLauncher, CommandLineGenerator.Args arguments, IProcessExecutor executor, StreamingStandardOutputTestResultParser streamingParser)
         {
             try
             {
-                return TryRunTests(executable, workingDir, envVars, isBeingDebugged, debuggedLauncher, arguments, resultXmlFile, executor, streamingParser);
+                return TryRunTests(executable, workingDir, envVars, isBeingDebugged, debuggedLauncher, arguments, executor, streamingParser);
             }
             catch (Exception e)
             {
@@ -176,8 +175,7 @@ namespace GoogleTestAdapter.Runners
         }
 
         private IEnumerable<TestResult> TryRunTests(string executable, string workingDir, IDictionary<string, string> envVars, bool isBeingDebugged,
-            IDebuggedProcessLauncher debuggedLauncher, CommandLineGenerator.Args arguments, string resultXmlFile, IProcessExecutor executor,
-            StreamingStandardOutputTestResultParser streamingParser)
+            IDebuggedProcessLauncher debuggedLauncher, CommandLineGenerator.Args arguments, IProcessExecutor executor, StreamingStandardOutputTestResultParser streamingParser)
         {
             List<string> consoleOutput;
             if (_settings.UseNewTestExecutionFramework)
@@ -197,7 +195,7 @@ namespace GoogleTestAdapter.Runners
             var remainingTestCases =
                 arguments.TestCases.Except(streamingParser.TestResults.Select(tr => tr.TestCase));
             var testResults = new TestResultCollector(_logger, _threadName)
-                .CollectTestResults(remainingTestCases, resultXmlFile, consoleOutput, streamingParser.CrashedTestCase);
+                .CollectTestResults(remainingTestCases, consoleOutput, streamingParser.CrashedTestCase);
             testResults = testResults.OrderBy(tr => tr.TestCase.FullyQualifiedName).ToList();
 
             return testResults;

--- a/GoogleTestAdapter/Core/Runners/TestResultCollector.cs
+++ b/GoogleTestAdapter/Core/Runners/TestResultCollector.cs
@@ -20,13 +20,10 @@ namespace GoogleTestAdapter.Runners
             _threadName = threadName;
         }
 
-        public List<TestResult> CollectTestResults(IEnumerable<TestCase> testCasesRun, string resultXmlFile, List<string> consoleOutput, TestCase crashedTestCase)
+        public List<TestResult> CollectTestResults(IEnumerable<TestCase> testCasesRun, List<string> consoleOutput, TestCase crashedTestCase)
         {
             var testResults = new List<TestResult>();
             TestCase[] arrTestCasesRun = testCasesRun as TestCase[] ?? testCasesRun.ToArray();
-
-            if (testResults.Count < arrTestCasesRun.Length)
-                CollectResultsFromXmlFile(arrTestCasesRun, resultXmlFile, testResults);
 
             var consoleParser = new StandardOutputTestResultParser(arrTestCasesRun, consoleOutput, _logger);
             if (testResults.Count < arrTestCasesRun.Length)
@@ -48,22 +45,6 @@ namespace GoogleTestAdapter.Runners
             }
 
             return testResults;
-        }
-
-        private void CollectResultsFromXmlFile(TestCase[] testCasesRun, string resultXmlFile, List<TestResult> testResults)
-        {
-            var xmlParser = new XmlTestResultParser(testCasesRun, resultXmlFile, _logger);
-            List<TestResult> xmlResults = xmlParser.GetTestResults();
-            int nrOfCollectedTestResults = 0;
-            foreach (TestResult testResult in xmlResults.Where(
-                tr => !testResults.Exists(tr2 => tr.TestCase.FullyQualifiedName == tr2.TestCase.FullyQualifiedName)))
-            {
-                testResults.Add(testResult);
-                nrOfCollectedTestResults++;
-            }
-            if (nrOfCollectedTestResults > 0)
-                _logger.DebugInfo(
-                    String.Format(Resources.CollectedResults, _threadName, nrOfCollectedTestResults, resultXmlFile));
         }
 
         private void CollectResultsFromConsoleOutput(StandardOutputTestResultParser consoleParser, List<TestResult> testResults)


### PR DESCRIPTION
We're using the new testing framework by default already which is a better system, so the files aren't being used in a majority of cases. We also fall back to parsing the standard output if we're not using the new framework, which works just fine and doesn't cause any issues with generation a ton of temp files for large testing suites.