### PR TITLE
fix test case regex to make sure we apply it to typed tests properly

### DIFF
--- a/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
+++ b/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
@@ -8,8 +8,8 @@ namespace GoogleTestAdapter.TestCases
 
     public class StreamingListTestsParser
     {
-        private static readonly Regex SuiteRegex = new Regex($@"([\S\/]*(?:\.[\S\/]+)*)(?:{Regex.Escape(GoogleTestConstants.TypedTestMarker)}(.*))?", RegexOptions.Compiled);
-        private static readonly Regex NameRegex = new Regex($@"([\S\/]*)(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
+        private static readonly Regex SuiteRegex = new Regex($@"([^.\s]*(?:\.[\S]+)*)(?:{Regex.Escape(GoogleTestConstants.TypedTestMarker)}(.*))?", RegexOptions.Compiled);
+        private static readonly Regex NameRegex = new Regex($@"([\S]*)(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
         private static readonly Regex IsParamRegex = new Regex(@"(\w+/)?\w+/\d+", RegexOptions.Compiled);
 
         private readonly string _testNameSeparator;


### PR DESCRIPTION
"\S\/" was redundant since "\S" includes "\/", and in SuiteRegex \S was too permissive, since we need to not include the "." for typed tests, so we explicitly exclude that in the negative case ([^\s] vs [\S]).