### PR TITLE
Tests with default settings can be treated as having no settings

### DIFF
--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -60,13 +60,12 @@ namespace GoogleTestAdapter.Runners
                     if (_settings.TestPropertySettingsContainer != null)
                     {
                         testsWithNoTestPropertySettings = new List<TestCase>();
-
                         foreach (var testCase in groupedTestCases[executable])
                         {
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
                             if (_settings.TestPropertySettingsContainer.TryGetSettings(testCase.FullyQualifiedName, out settings)
-                                && (settings.Environment.Count > 0 || settings.WorkingDirectory != finalWorkingDir))
+                                && (settings.Environment.Count > 0 || Path.GetFullPath(settings.WorkingDirectory) != Path.GetFullPath(finalWorkingDir)))
                             {
                                 RunTestsFromExecutable(
                                     executable,

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -60,6 +60,7 @@ namespace GoogleTestAdapter.Runners
                     if (_settings.TestPropertySettingsContainer != null)
                     {
                         testsWithNoTestPropertySettings = new List<TestCase>();
+
                         foreach (var testCase in groupedTestCases[executable])
                         {
                             ITestPropertySettings settings;

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -1,4 +1,4 @@
-﻿// This file has been modified by Microsoft on 1/2021.
+﻿// This file has been modified by Microsoft on 10/2022.
 
 using System;
 using System.Collections.Generic;
@@ -64,7 +64,9 @@ namespace GoogleTestAdapter.Runners
                         foreach (var testCase in groupedTestCases[executable])
                         {
                             ITestPropertySettings settings;
-                            if (_settings.TestPropertySettingsContainer.TryGetSettings(testCase.FullyQualifiedName, out settings))
+                            // Tests with default settings are treated as not having settings and can be run together
+                            if (_settings.TestPropertySettingsContainer.TryGetSettings(testCase.FullyQualifiedName, out settings)
+                                && (settings.Environment.Count > 0 || settings.WorkingDirectory != finalWorkingDir))
                             {
                                 RunTestsFromExecutable(
                                     executable,


### PR DESCRIPTION
In the CMake case. it fills in the settings with the defaults, which means they all run individually which can cause issues with debugging. For tests with different settings specified, we still need to launch them on their own, but for tests with default settings we can run them with the rest of the tests.