### PR TITLE
Update settings container to use source + test name as key

### DIFF
--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -1,4 +1,4 @@
-﻿// This file has been modified by Microsoft on 10/2022.
+﻿// This file has been modified by Microsoft on 11/2022.
 
 using System;
 using System.Collections.Generic;
@@ -63,9 +63,10 @@ namespace GoogleTestAdapter.Runners
 
                         foreach (var testCase in groupedTestCases[executable])
                         {
+                            var key = testCase.Source + ":" + testCase.FullyQualifiedName;
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
-                            if (_settings.TestPropertySettingsContainer.TryGetSettings(testCase.FullyQualifiedName, out settings)
+                            if (_settings.TestPropertySettingsContainer.TryGetSettings(key, out settings)
                                 && (settings.Environment.Count > 0 || Path.GetFullPath(settings.WorkingDirectory) != Path.GetFullPath(finalWorkingDir)))
                             {
                                 RunTestsFromExecutable(

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -63,7 +63,7 @@ namespace GoogleTestAdapter.Runners
 
                         foreach (var testCase in groupedTestCases[executable])
                         {
-                            var key = testCase.Source + ":" + testCase.FullyQualifiedName;
+                            var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedName;
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
                             if (_settings.TestPropertySettingsContainer.TryGetSettings(key, out settings)

--- a/GoogleTestAdapter/Core/Settings/ITestPropertySettingsContainer.cs
+++ b/GoogleTestAdapter/Core/Settings/ITestPropertySettingsContainer.cs
@@ -3,6 +3,6 @@ namespace GoogleTestAdapter.Settings
 {
     public interface ITestPropertySettingsContainer
     {
-        bool TryGetSettings(string testName, out ITestPropertySettings settings);
+        bool TryGetSettings(string key, out ITestPropertySettings settings);
     }
 }

--- a/GoogleTestAdapter/GoogleTestAdapter.ChildProcessDbgSettings
+++ b/GoogleTestAdapter/GoogleTestAdapter.ChildProcessDbgSettings
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ChildProcessDebuggingSettings IsEnabled="true" xmlns="http://schemas.microsoft.com/vstudio/ChildProcessDebuggingSettings/2014">
-  <DefaultRule Attach="false" />
+  <DefaultRule EngineFilter="[inherit]" />
   <Rule IsEnabled="true" ProcessName="TE.ProcessHost.Managed.exe" EngineFilter="{92ef0900-2251-11d2-b72e-0000f87572ef}" />
   <Rule IsEnabled="true" ProcessName="vstest.discoveryengine.exe" EngineFilter="{92ef0900-2251-11d2-b72e-0000f87572ef}" />
   <Rule IsEnabled="true" ProcessName="vstest.discoveryengine.x86.exe" EngineFilter="{92ef0900-2251-11d2-b72e-0000f87572ef}" />

--- a/GoogleTestAdapter/TestAdapter/Settings/TestPropertySettingsContainer.cs
+++ b/GoogleTestAdapter/TestAdapter/Settings/TestPropertySettingsContainer.cs
@@ -5,6 +5,7 @@
 using GoogleTestAdapter.Settings;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using System.Collections.Generic;
+using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
 

--- a/GoogleTestAdapter/TestAdapter/Settings/TestPropertySettingsContainer.cs
+++ b/GoogleTestAdapter/TestAdapter/Settings/TestPropertySettingsContainer.cs
@@ -65,7 +65,7 @@ namespace GoogleTestAdapter.TestAdapter.Settings
             {
                 foreach (var t in this.Tests)
                 {
-                    var key = t.Command + ":" + t.Name;
+                    var key = Path.GetFullPath(t.Command) + ":" + t.Name;
                     var propertySettings = new TestPropertySettings(t);
                     _tests.Add(key, propertySettings);
                 }

--- a/GoogleTestAdapter/TestAdapter/Settings/TestPropertySettingsContainer.cs
+++ b/GoogleTestAdapter/TestAdapter/Settings/TestPropertySettingsContainer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+// This file has been modified by Microsoft on 11/2022.
 
 using GoogleTestAdapter.Settings;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -46,10 +47,10 @@ namespace GoogleTestAdapter.TestAdapter.Settings
             return document.DocumentElement;
         }
 
-        public bool TryGetSettings(string testName, out ITestPropertySettings settings)
+        public bool TryGetSettings(string key, out ITestPropertySettings settings)
         {
             EnsureTestPropertiesMap();
-            return _tests.TryGetValue(testName, out settings);
+            return _tests.TryGetValue(key, out settings);
         }
 
         private void EnsureTestPropertiesMap()
@@ -64,8 +65,9 @@ namespace GoogleTestAdapter.TestAdapter.Settings
             {
                 foreach (var t in this.Tests)
                 {
+                    var key = t.Command + ":" + t.Name;
                     var propertySettings = new TestPropertySettings(t);
-                    _tests.Add(t.Name, propertySettings);
+                    _tests.Add(key, propertySettings);
                 }
             }
         }


### PR DESCRIPTION
You can have multiple tests with the same name coming from different test exes, so we need to be mor explicit when store and query settings.