### PR TITLE
Resolve bug that added duplicate keys to _tests dictionary

### DIFF
--- a/GoogleTestAdapter/TestAdapter/Settings/TestPropertySettingsContainer.cs
+++ b/GoogleTestAdapter/TestAdapter/Settings/TestPropertySettingsContainer.cs
@@ -67,8 +67,11 @@ namespace GoogleTestAdapter.TestAdapter.Settings
                 foreach (var t in this.Tests)
                 {
                     var key = Path.GetFullPath(t.Command) + ":" + t.Name;
-                    var propertySettings = new TestPropertySettings(t);
-                    _tests.Add(key, propertySettings);
+                    if (!_tests.ContainsKey(key))
+                    {
+                        var propertySettings = new TestPropertySettings(t);
+                        _tests.Add(key, propertySettings);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Ensure that the given key does not exist prior to trying to add it to the _tests dictionary. Previously this threw an exception and resulted in being unable to run google tests.
Tied to work item: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1410173/