### PR TITLE
Fix Google Test project builds with ARM64

### DIFF
--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
@@ -17,7 +17,7 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-	$arm64config$
+	  $arm64config$
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{$guid1$}</ProjectGuid>

--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
@@ -43,6 +43,8 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <ItemDefinitionGroup />

--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
@@ -43,8 +43,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
+      $arm64Pch$
     </ClCompile>
   </ItemGroup>
   <ItemDefinitionGroup />

--- a/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
+++ b/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
@@ -23,12 +23,14 @@ namespace Microsoft.NewProjectWizard
         private const string TargetPlatformVersion = "$targetplatformversion$";
         private const string WizardData = "$wizarddata$";
         private const string RuntimeDebug = "$rtdebug$";
+        private string RuntimeDebugValue = "MultiThreadedDebugDLL";
         private const string RuntimeRelease = "$rtrelease$";
+        private string RuntimeReleasevalue = "MultiThreadedDLL";
         private const string RunSilent = "$runsilent$";
         private const string ARM64DebugPlatform = "$arm64debugplatform$";
-        private string arm64DebugXMLChunk = "  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Debug|ARM64'\"> <ClCompile>  <PrecompiledHeader>Use</PrecompiledHeader>  <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>  <Optimization>Disabled</Optimization>  <PreprocessorDefinitions>ARM64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>   <RuntimeLibrary>$rtdebug$</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem> </Link>  </ItemDefinitionGroup>";
+        private string arm64DebugXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Debug|ARM64'\"> <ClCompile>  <PrecompiledHeader>Use</PrecompiledHeader>  <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>  <Optimization>Disabled</Optimization>  <PreprocessorDefinitions>ARM64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>   <RuntimeLibrary>{RuntimeDebugValue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem> </Link>  </ItemDefinitionGroup>";
         private const string ARM64ReleasePlatform = "$arm64releaseplatform$";
-        private string arm64ReleaseXMLChunk = "  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Release|ARM64'\"> <ClCompile>   <PrecompiledHeader>Use</PrecompiledHeader>   <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>   <PreprocessorDefinitions>ARM64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <RuntimeLibrary>$rtrelease$</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel>   <DebugInformationFormat>ProgramDatabase</DebugInformationFormat> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem>   <OptimizeReferences>true</OptimizeReferences>   <EnableCOMDATFolding>true</EnableCOMDATFolding> </Link>  </ItemDefinitionGroup>";
+        private string arm64ReleaseXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Release|ARM64'\"> <ClCompile>   <PrecompiledHeader>Use</PrecompiledHeader>   <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>   <PreprocessorDefinitions>ARM64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <RuntimeLibrary>{RuntimeReleasevalue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel>   <DebugInformationFormat>ProgramDatabase</DebugInformationFormat> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem>   <OptimizeReferences>true</OptimizeReferences>   <EnableCOMDATFolding>true</EnableCOMDATFolding> </Link>  </ItemDefinitionGroup>";
         private const string ARM64Config = "$arm64config$";
         private string arm64ConfigXML = "<ProjectConfiguration Include=\"Debug|ARM64\">   <Configuration>Debug</Configuration>   <Platform>ARM64</Platform> </ProjectConfiguration> <ProjectConfiguration Include=\"Release|ARM64\"> <Configuration>Release</Configuration>  <Platform>ARM64</Platform> </ProjectConfiguration>";
         private List<Project> projects = new List<Project>();
@@ -153,14 +155,17 @@ namespace Microsoft.NewProjectWizard
 
             if (configurationData.IsRuntimeStatic)
             {
-                replacementsDictionary[RuntimeRelease] = "MultiThreaded";
-                replacementsDictionary[RuntimeDebug] = "MultiThreadedDebug";
+                RuntimeReleasevalue = "MultiThreaded";
+                RuntimeDebugValue = "MultiThreadedDebug";
             }
             else
             {
-                replacementsDictionary[RuntimeRelease] = "MultiThreadedDLL";
-                replacementsDictionary[RuntimeDebug] = "MultiThreadedDebugDLL";
+                RuntimeReleasevalue = "MultiThreadedDLL";
+                RuntimeDebugValue =  "MultiThreadedDebugDLL";
             }
+
+            replacementsDictionary[RuntimeRelease] = RuntimeReleasevalue;
+            replacementsDictionary[RuntimeDebug] = RuntimeDebugValue;
 
             if (!isPlatformSet)
             {

--- a/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
+++ b/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
@@ -29,6 +29,8 @@ namespace Microsoft.NewProjectWizard
         private const string ARM64ReleasePlatform = "$arm64releaseplatform$";
         private const string ARM64Config = "$arm64config$";
         private string arm64ConfigXML = "<ProjectConfiguration Include=\"Debug|ARM64\">   <Configuration>Debug</Configuration>   <Platform>ARM64</Platform> </ProjectConfiguration> <ProjectConfiguration Include=\"Release|ARM64\"> <Configuration>Release</Configuration>  <Platform>ARM64</Platform> </ProjectConfiguration>";
+        private const string ARM64Pch = "$arm64Pch$";
+        private string ARM64PchXML = "<PrecompiledHeader Condition=\"'$(Configuration)|$(Platform)'=='Debug|ARM64'\">Create</PrecompiledHeader>   <PrecompiledHeader Condition=\"'$(Configuration)|$(Platform)'=='Release|ARM64'\">Create</PrecompiledHeader>";
         private List<Project> projects = new List<Project>();
         private int selectedProjectIndex;
         private IWizard nugetWizard;
@@ -150,21 +152,21 @@ namespace Microsoft.NewProjectWizard
             }
 
             string RuntimeDebugValue = "MultiThreadedDebugDLL";
-            string RuntimeReleasevalue = "MultiThreadedDLL";
+            string RuntimeReleaseValue = "MultiThreadedDLL";
             if (configurationData.IsRuntimeStatic)
             {
-                RuntimeReleasevalue = "MultiThreaded";
+                RuntimeReleaseValue = "MultiThreaded";
                 RuntimeDebugValue = "MultiThreadedDebug";
             }
             else
             {
-                RuntimeReleasevalue = "MultiThreadedDLL";
+                RuntimeReleaseValue = "MultiThreadedDLL";
                 RuntimeDebugValue =  "MultiThreadedDebugDLL";
             }
 
             string arm64DebugXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Debug|ARM64'\"> <ClCompile>  <PrecompiledHeader>Use</PrecompiledHeader>  <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>  <Optimization>Disabled</Optimization>  <PreprocessorDefinitions>ARM64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>   <RuntimeLibrary>{RuntimeDebugValue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem> </Link>  </ItemDefinitionGroup>";
-            string arm64ReleaseXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Release|ARM64'\"> <ClCompile>   <PrecompiledHeader>Use</PrecompiledHeader>   <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>   <PreprocessorDefinitions>ARM64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <RuntimeLibrary>{RuntimeReleasevalue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel>   <DebugInformationFormat>ProgramDatabase</DebugInformationFormat> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem>   <OptimizeReferences>true</OptimizeReferences>   <EnableCOMDATFolding>true</EnableCOMDATFolding> </Link>  </ItemDefinitionGroup>";
-            replacementsDictionary[RuntimeRelease] = RuntimeReleasevalue;
+            string arm64ReleaseXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Release|ARM64'\"> <ClCompile>   <PrecompiledHeader>Use</PrecompiledHeader>   <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>   <PreprocessorDefinitions>ARM64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <RuntimeLibrary>{RuntimeReleaseValue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel>   <DebugInformationFormat>ProgramDatabase</DebugInformationFormat> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem>   <OptimizeReferences>true</OptimizeReferences>   <EnableCOMDATFolding>true</EnableCOMDATFolding> </Link>  </ItemDefinitionGroup>";
+            replacementsDictionary[RuntimeRelease] = RuntimeReleaseValue;
             replacementsDictionary[RuntimeDebug] = RuntimeDebugValue;
 
             if (!isPlatformSet)
@@ -192,8 +194,10 @@ namespace Microsoft.NewProjectWizard
                         arm64DebugXMLChunk = "";
                         arm64ReleaseXMLChunk = "";
                         arm64ConfigXML = "";
+                        ARM64PchXML = "";
                     }
                     replacementsDictionary[ARM64Config] = arm64ConfigXML;
+                    replacementsDictionary[ARM64Pch] = ARM64PchXML;
                     replacementsDictionary[ARM64DebugPlatform] = arm64DebugXMLChunk;
                     replacementsDictionary[ARM64ReleasePlatform] = arm64ReleaseXMLChunk;
 

--- a/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
+++ b/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NewProjectWizard
         private const string ARM64Config = "$arm64config$";
         private string arm64ConfigXML = "<ProjectConfiguration Include=\"Debug|ARM64\">   <Configuration>Debug</Configuration>   <Platform>ARM64</Platform> </ProjectConfiguration> <ProjectConfiguration Include=\"Release|ARM64\"> <Configuration>Release</Configuration>  <Platform>ARM64</Platform> </ProjectConfiguration>";
         private const string ARM64Pch = "$arm64Pch$";
-        private string ARM64PchXML = "<PrecompiledHeader Condition=\"'$(Configuration)|$(Platform)'=='Debug|ARM64'\">Create</PrecompiledHeader>   <PrecompiledHeader Condition=\"'$(Configuration)|$(Platform)'=='Release|ARM64'\">Create</PrecompiledHeader>";
+        private string arm64PchXML = "<PrecompiledHeader Condition=\"'$(Configuration)|$(Platform)'=='Debug|ARM64'\">Create</PrecompiledHeader>   <PrecompiledHeader Condition=\"'$(Configuration)|$(Platform)'=='Release|ARM64'\">Create</PrecompiledHeader>";
         private List<Project> projects = new List<Project>();
         private int selectedProjectIndex;
         private IWizard nugetWizard;
@@ -155,19 +155,19 @@ namespace Microsoft.NewProjectWizard
             string RuntimeReleaseValue = "MultiThreadedDLL";
             if (configurationData.IsRuntimeStatic)
             {
-                RuntimeReleaseValue = "MultiThreaded";
                 RuntimeDebugValue = "MultiThreadedDebug";
+                RuntimeReleaseValue = "MultiThreaded";
             }
             else
             {
-                RuntimeReleaseValue = "MultiThreadedDLL";
                 RuntimeDebugValue =  "MultiThreadedDebugDLL";
+                RuntimeReleaseValue = "MultiThreadedDLL";
             }
 
             string arm64DebugXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Debug|ARM64'\"> <ClCompile>  <PrecompiledHeader>Use</PrecompiledHeader>  <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>  <Optimization>Disabled</Optimization>  <PreprocessorDefinitions>ARM64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>   <RuntimeLibrary>{RuntimeDebugValue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem> </Link>  </ItemDefinitionGroup>";
             string arm64ReleaseXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Release|ARM64'\"> <ClCompile>   <PrecompiledHeader>Use</PrecompiledHeader>   <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>   <PreprocessorDefinitions>ARM64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <RuntimeLibrary>{RuntimeReleaseValue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel>   <DebugInformationFormat>ProgramDatabase</DebugInformationFormat> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem>   <OptimizeReferences>true</OptimizeReferences>   <EnableCOMDATFolding>true</EnableCOMDATFolding> </Link>  </ItemDefinitionGroup>";
-            replacementsDictionary[RuntimeRelease] = RuntimeReleaseValue;
             replacementsDictionary[RuntimeDebug] = RuntimeDebugValue;
+            replacementsDictionary[RuntimeRelease] = RuntimeReleaseValue;
 
             if (!isPlatformSet)
             {
@@ -191,13 +191,13 @@ namespace Microsoft.NewProjectWizard
                         .OrderByDescending(p => p.Version).ToList();
 
                     if (!this.IsARM64()) {
+                        arm64ConfigXML = "";
+                        arm64PchXML = "";
                         arm64DebugXMLChunk = "";
                         arm64ReleaseXMLChunk = "";
-                        arm64ConfigXML = "";
-                        ARM64PchXML = "";
                     }
                     replacementsDictionary[ARM64Config] = arm64ConfigXML;
-                    replacementsDictionary[ARM64Pch] = ARM64PchXML;
+                    replacementsDictionary[ARM64Pch] = arm64PchXML;
                     replacementsDictionary[ARM64DebugPlatform] = arm64DebugXMLChunk;
                     replacementsDictionary[ARM64ReleasePlatform] = arm64ReleaseXMLChunk;
 

--- a/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
+++ b/GoogleTestAdapter/NewProjectWizard/WizardImplementation.cs
@@ -23,14 +23,10 @@ namespace Microsoft.NewProjectWizard
         private const string TargetPlatformVersion = "$targetplatformversion$";
         private const string WizardData = "$wizarddata$";
         private const string RuntimeDebug = "$rtdebug$";
-        private string RuntimeDebugValue = "MultiThreadedDebugDLL";
         private const string RuntimeRelease = "$rtrelease$";
-        private string RuntimeReleasevalue = "MultiThreadedDLL";
         private const string RunSilent = "$runsilent$";
         private const string ARM64DebugPlatform = "$arm64debugplatform$";
-        private string arm64DebugXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Debug|ARM64'\"> <ClCompile>  <PrecompiledHeader>Use</PrecompiledHeader>  <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>  <Optimization>Disabled</Optimization>  <PreprocessorDefinitions>ARM64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>   <RuntimeLibrary>{RuntimeDebugValue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem> </Link>  </ItemDefinitionGroup>";
         private const string ARM64ReleasePlatform = "$arm64releaseplatform$";
-        private string arm64ReleaseXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Release|ARM64'\"> <ClCompile>   <PrecompiledHeader>Use</PrecompiledHeader>   <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>   <PreprocessorDefinitions>ARM64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <RuntimeLibrary>{RuntimeReleasevalue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel>   <DebugInformationFormat>ProgramDatabase</DebugInformationFormat> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem>   <OptimizeReferences>true</OptimizeReferences>   <EnableCOMDATFolding>true</EnableCOMDATFolding> </Link>  </ItemDefinitionGroup>";
         private const string ARM64Config = "$arm64config$";
         private string arm64ConfigXML = "<ProjectConfiguration Include=\"Debug|ARM64\">   <Configuration>Debug</Configuration>   <Platform>ARM64</Platform> </ProjectConfiguration> <ProjectConfiguration Include=\"Release|ARM64\"> <Configuration>Release</Configuration>  <Platform>ARM64</Platform> </ProjectConfiguration>";
         private List<Project> projects = new List<Project>();
@@ -153,6 +149,8 @@ namespace Microsoft.NewProjectWizard
                 throw;
             }
 
+            string RuntimeDebugValue = "MultiThreadedDebugDLL";
+            string RuntimeReleasevalue = "MultiThreadedDLL";
             if (configurationData.IsRuntimeStatic)
             {
                 RuntimeReleasevalue = "MultiThreaded";
@@ -164,6 +162,8 @@ namespace Microsoft.NewProjectWizard
                 RuntimeDebugValue =  "MultiThreadedDebugDLL";
             }
 
+            string arm64DebugXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Debug|ARM64'\"> <ClCompile>  <PrecompiledHeader>Use</PrecompiledHeader>  <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>  <Optimization>Disabled</Optimization>  <PreprocessorDefinitions>ARM64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>   <RuntimeLibrary>{RuntimeDebugValue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem> </Link>  </ItemDefinitionGroup>";
+            string arm64ReleaseXMLChunk = $"  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='Release|ARM64'\"> <ClCompile>   <PrecompiledHeader>Use</PrecompiledHeader>   <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>   <PreprocessorDefinitions>ARM64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>   <RuntimeLibrary>{RuntimeReleasevalue}</RuntimeLibrary>   <WarningLevel>Level3</WarningLevel>   <DebugInformationFormat>ProgramDatabase</DebugInformationFormat> </ClCompile> <Link>   <GenerateDebugInformation>true</GenerateDebugInformation>   <SubSystem>Console</SubSystem>   <OptimizeReferences>true</OptimizeReferences>   <EnableCOMDATFolding>true</EnableCOMDATFolding> </Link>  </ItemDefinitionGroup>";
             replacementsDictionary[RuntimeRelease] = RuntimeReleasevalue;
             replacementsDictionary[RuntimeDebug] = RuntimeDebugValue;
 


### PR DESCRIPTION
Add condition to create .pch file when using ARM64. Previously, ARM64 builds also failed because we passed static $rtdebug$ and $rerelease$ string into the xml chunk which could not be read, so now we use dynamic runtime values and pass those strings into the xml chunks.
Also added $arm64Pch$ variable to add create pch option only when arm64 conditions are met.