### PR TITLE
Fix bug where paramaterized tests do not run

### DIFF
--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -63,7 +63,7 @@ namespace GoogleTestAdapter.Runners
 
                         foreach (var testCase in groupedTestCases[executable])
                         {
-                            var key = Path.GetFullPath(testCase.Source) + ":" + testCase.DisplayName;
+                            var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedName;
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
                             if (_settings.TestPropertySettingsContainer.TryGetSettings(key, out settings)


### PR DESCRIPTION
Previously using tc.DisplayName causes a regression where paramaterized tests were not run. Therefore, we are switching back to FQN, but removing the namespace if it exists in the test case FQN, otherwise the names will not match since the console output name does not include namespaces.
Regression caused by this PR: https://github.com/microsoft/TestAdapterForGoogleTest/pull/225