### PR TITLE
Move arm64 config to top of list

### DIFF
--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    $arm64config$
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -17,7 +18,6 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-	  $arm64config$
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{$guid1$}</ProjectGuid>


### PR DESCRIPTION
Move arm64 config to top of list in attempt to set it as the default for ARM 64 bit machines rather than the x64 configurations.