### PR TITLE
Fix Bug: Cannot run individual tests inside of namespaces

### DIFF
--- a/GoogleTestAdapter/Core/Model/TestCase.cs
+++ b/GoogleTestAdapter/Core/Model/TestCase.cs
@@ -12,6 +12,8 @@ namespace GoogleTestAdapter.Model
         public string CodeFilePath { get; }
         public int LineNumber { get; }
 
+        public string Namespace { get; set; }
+
         public List<Trait> Traits { get; } = new List<Trait>();
         public List<TestProperty> Properties { get; } = new List<TestProperty>();
 

--- a/GoogleTestAdapter/Core/Model/TestCase.cs
+++ b/GoogleTestAdapter/Core/Model/TestCase.cs
@@ -6,7 +6,7 @@ namespace GoogleTestAdapter.Model
     {
         public string Source { get; }
 
-        public string FullyQualifiedName { get; }
+        public string FullyQualifiedName { get; set; }
         public string DisplayName { get; }
 
         public string CodeFilePath { get; }

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -63,7 +63,17 @@ namespace GoogleTestAdapter.Runners
 
                         foreach (var testCase in groupedTestCases[executable])
                         {
-                            var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedName;
+                            string fullyQualifiedName = testCase.FullyQualifiedName;
+
+                            // If testCase contains a namespace then remove it because GoogleTest has no knowledge of namespaces.
+                            int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
+
+                            if (frequency > 1)
+                            {
+                                fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
+                            }
+
+                            var key = Path.GetFullPath(testCase.Source) + ":" + fullyQualifiedName;
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
                             if (_settings.TestPropertySettingsContainer.TryGetSettings(key, out settings)

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -63,17 +63,8 @@ namespace GoogleTestAdapter.Runners
 
                         foreach (var testCase in groupedTestCases[executable])
                         {
-                            string fullyQualifiedName = testCase.FullyQualifiedName;
+                            var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedName;
 
-                            // If testCase contains a namespace then remove it because GoogleTest has no knowledge of namespaces.
-                            int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
-
-                            if (frequency > 1)
-                            {
-                                fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
-                            }
-
-                            var key = Path.GetFullPath(testCase.Source) + ":" + fullyQualifiedName;
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
                             if (_settings.TestPropertySettingsContainer.TryGetSettings(key, out settings)

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -64,7 +64,6 @@ namespace GoogleTestAdapter.Runners
                         foreach (var testCase in groupedTestCases[executable])
                         {
                             var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedName;
-
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
                             if (_settings.TestPropertySettingsContainer.TryGetSettings(key, out settings)
@@ -181,6 +180,24 @@ namespace GoogleTestAdapter.Runners
         private IEnumerable<TestResult> TryRunTests(string executable, string workingDir, IDictionary<string, string> envVars, bool isBeingDebugged,
             IDebuggedProcessLauncher debuggedLauncher, CommandLineGenerator.Args arguments, IProcessExecutor executor, StreamingStandardOutputTestResultParser streamingParser)
         {
+            foreach (TestCase tc in arguments.TestCases)
+            {
+                // If namespace exists then remove it so we can compare the test display names.
+                //  Using just tc.DisplayName does not work for paramaterized test cases.
+                string fullyQualifiedName = tc.FullyQualifiedName;
+                int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
+                if (frequency > 1)
+                {
+                    string ns = fullyQualifiedName.Substring(0, fullyQualifiedName.IndexOf('.'));
+                    tc.Namespace = ns;
+                    _logger.LogInfo("NS removing: " + tc.Namespace);
+                    fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
+                }
+
+                tc.FullyQualifiedName = fullyQualifiedName;
+                _logger.LogInfo("Test Name after removing NS: " + tc.FullyQualifiedName);
+            }
+
             List<string> consoleOutput;
             if (_settings.UseNewTestExecutionFramework)
             {

--- a/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
@@ -196,24 +196,7 @@ namespace GoogleTestAdapter.TestResults
 
         public static TestCase FindTestcase(string qualifiedTestname, IList<TestCase> testCasesRun)
         {
-            foreach (TestCase tc in testCasesRun)
-            {
-                // If namespace exists then remove it so we can compare the test display names.
-                //  Using just tc.DisplayName does not work for paramaterized test cases.
-                string fullyQualifiedName = tc.FullyQualifiedName;
-                int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
-                if (frequency > 1)
-                {
-                    fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
-                }
-
-                if (fullyQualifiedName == qualifiedTestname)
-                {
-                    return tc;
-                }
-            }
-
-            return null;
+            return testCasesRun.SingleOrDefault(tc => tc.FullyQualifiedName == qualifiedTestname);
         }
 
         public static bool IsRunLine(string line)

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -229,24 +229,6 @@ namespace GoogleTestAdapter.TestAdapter
 
                 _executor = new GoogleTestExecutor(_logger, _settings);
             }
-            foreach (TestCase tc in testCasesToRun)
-            {
-                // If namespace exists then remove it so we can compare the test display names.
-                //  Using just tc.DisplayName does not work for paramaterized test cases.
-                string fullyQualifiedName = tc.FullyQualifiedName;
-                int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
-                if (frequency > 1)
-                {
-                    string ns = fullyQualifiedName.Substring(0, fullyQualifiedName.IndexOf('.'));
-                    tc.Namespace = ns;
-                    _logger.LogInfo("NS removing: " + tc.Namespace);
-                    fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
-                }
-
-                tc.FullyQualifiedName = fullyQualifiedName;
-                _logger.LogInfo("Test Name after removing NS: " + tc.FullyQualifiedName);
-            }
-
             _executor.RunTests(testCasesToRun, reporter, launcher,
                 runContext.IsBeingDebugged, runContext.SolutionDirectory, processExecutor);
             reporter.AllTestsFinished();

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -229,6 +229,20 @@ namespace GoogleTestAdapter.TestAdapter
 
                 _executor = new GoogleTestExecutor(_logger, _settings);
             }
+            foreach (TestCase tc in testCasesToRun)
+            {
+                // If namespace exists then remove it so we can compare the test display names.
+                //  Using just tc.DisplayName does not work for paramaterized test cases.
+                string fullyQualifiedName = tc.FullyQualifiedName;
+                int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
+                if (frequency > 1)
+                {
+                    fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
+                }
+
+                tc.FullyQualifiedName = fullyQualifiedName;
+            }
+
             _executor.RunTests(testCasesToRun, reporter, launcher,
                 runContext.IsBeingDebugged, runContext.SolutionDirectory, processExecutor);
             reporter.AllTestsFinished();

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -237,10 +237,14 @@ namespace GoogleTestAdapter.TestAdapter
                 int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
                 if (frequency > 1)
                 {
+                    string ns = fullyQualifiedName.Substring(0, fullyQualifiedName.IndexOf('.'));
+                    tc.Namespace = ns;
+                    _logger.LogInfo("NS removing: " + tc.Namespace);
                     fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
                 }
 
                 tc.FullyQualifiedName = fullyQualifiedName;
+                _logger.LogInfo("Test Name after removing NS: " + tc.FullyQualifiedName);
             }
 
             _executor.RunTests(testCasesToRun, reporter, launcher,


### PR DESCRIPTION
Previously passing the entire fully qualified name caused a regression where gtest could not run individual tests that are contained within a namespace, because gtest has no knowledge of namespaces. So, when test explorer passes tests to run to the test adapter we remove the namespace at a more root level (DoRunTests).