### PR TITLE
Revert Namespace Functionality PR

### DIFF
--- a/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
@@ -253,13 +253,8 @@ namespace GoogleTestAdapter.TestCases
         {
             if (location != null)
             {
-                var ns = GetTestSignatureNamespace(location.TestClassSignature);
-
-                if (ns != string.Empty)
-                    ns += ".";
-
                 var testCase = new TestCase(
-                    ns + descriptor.FullyQualifiedName, _executable, descriptor.DisplayName, location.Sourcefile, (int)location.Line);
+                    descriptor.FullyQualifiedName, _executable, descriptor.DisplayName, location.Sourcefile, (int)location.Line);
                 testCase.Traits.AddRange(GetFinalTraits(descriptor.DisplayName, location.Traits));
                 return testCase;
             }

--- a/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
@@ -196,24 +196,7 @@ namespace GoogleTestAdapter.TestResults
 
         public static TestCase FindTestcase(string qualifiedTestname, IList<TestCase> testCasesRun)
         {
-            foreach (TestCase tc in testCasesRun)
-            {
-                // If namespace exists then remove it so we can compare the test display names.
-                //  Using just tc.DisplayName does not work for paramaterized test cases.
-                string fullyQualifiedName = tc.FullyQualifiedName;
-                int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
-                if (frequency > 1)
-                {
-                    fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
-                }
-
-                if (fullyQualifiedName == qualifiedTestname)
-                {
-                    return tc;
-                }
-            }
-
-            return null;
+            return testCasesRun.SingleOrDefault(tc => tc.FullyQualifiedName == qualifiedTestname);
         }
 
         public static bool IsRunLine(string line)


### PR DESCRIPTION
Revert functionality that added namespaces to tests due to a regression where individual tests that contain namespaces could not run.