### PR TITLE
Fix Bug: Namespace Tests Do Not Run

### DIFF
--- a/GoogleTestAdapter/Core.Tests/Scheduling/TestDurationSerializerTests.cs
+++ b/GoogleTestAdapter/Core.Tests/Scheduling/TestDurationSerializerTests.cs
@@ -125,7 +125,7 @@ namespace GoogleTestAdapter.Scheduling
             serializer.UpdateTestDurations(testResults);
 
             IDictionary<Model.TestCase, int> durations = serializer.ReadTestDurations(
-                new Model.TestCase("TestSuite1.Test2", tempFile, "TestSuite1.Test2", "", 0).Yield());
+                new Model.TestCase("TestSuite1.Test2", "TestSuite1.Test2", tempFile, "TestSuite1.Test2", "", 0).Yield());
 
             durations.Should().NotBeNull();
             durations.Count.Should().Be(0);

--- a/GoogleTestAdapter/Core/Model/TestCase.cs
+++ b/GoogleTestAdapter/Core/Model/TestCase.cs
@@ -12,6 +12,8 @@ namespace GoogleTestAdapter.Model
         public string CodeFilePath { get; }
         public int LineNumber { get; }
 
+        public string Namespace { get; set; }
+
         public List<Trait> Traits { get; } = new List<Trait>();
         public List<TestProperty> Properties { get; } = new List<TestProperty>();
 

--- a/GoogleTestAdapter/Core/Model/TestCase.cs
+++ b/GoogleTestAdapter/Core/Model/TestCase.cs
@@ -6,20 +6,20 @@ namespace GoogleTestAdapter.Model
     {
         public string Source { get; }
 
-        public string FullyQualifiedName { get; set; }
+        public string FullyQualifiedName { get; }
+        public string FullyQualifiedNameWithNamespace { get; }
         public string DisplayName { get; }
 
         public string CodeFilePath { get; }
         public int LineNumber { get; }
 
-        public string Namespace { get; set; }
-
         public List<Trait> Traits { get; } = new List<Trait>();
         public List<TestProperty> Properties { get; } = new List<TestProperty>();
 
-        public TestCase(string fullyQualifiedName, string source, string displayName, string codeFilePath, int lineNumber)
+        public TestCase(string fullyQualifiedName, string fullyQualifiedNameWithNamespace, string source, string displayName, string codeFilePath, int lineNumber)
         {
             FullyQualifiedName = fullyQualifiedName;
+            FullyQualifiedNameWithNamespace = fullyQualifiedNameWithNamespace;
             Source = source;
             DisplayName = displayName;
             CodeFilePath = codeFilePath;

--- a/GoogleTestAdapter/Core/Model/TestCase.cs
+++ b/GoogleTestAdapter/Core/Model/TestCase.cs
@@ -6,7 +6,7 @@ namespace GoogleTestAdapter.Model
     {
         public string Source { get; }
 
-        public string FullyQualifiedName { get; }
+        public string FullyQualifiedName { get; set; }
         public string DisplayName { get; }
 
         public string CodeFilePath { get; }

--- a/GoogleTestAdapter/Core/Model/TestCaseMetaDataProperty.cs
+++ b/GoogleTestAdapter/Core/Model/TestCaseMetaDataProperty.cs
@@ -10,19 +10,21 @@ namespace GoogleTestAdapter.Model
 
         public int NrOfTestCasesInSuite { get; }
         public int NrOfTestCasesInExecutable { get; }
+        public string FullyQualifiedNameWithoutNamespace { get; }
 
-        public TestCaseMetaDataProperty(int nrOfTestCasesInSuite, int nrOfTestCasesInExecutable)
-            : this($"{nrOfTestCasesInSuite}:{nrOfTestCasesInExecutable}")
+        public TestCaseMetaDataProperty(int nrOfTestCasesInSuite, int nrOfTestCasesInExecutable, string fullyQualifiedNameWithoutNamespace)
+            : this($"{nrOfTestCasesInSuite}|{nrOfTestCasesInExecutable}|{fullyQualifiedNameWithoutNamespace}")
         {
         }
 
         public TestCaseMetaDataProperty(string serialization) : base(serialization)
         {
-            int[] values = serialization.Split(':').Select(int.Parse).ToArray();
-            if (values.Length != 2)
+            string[] fields = serialization.Split('|');
+            if (fields.Length != 3)
                 throw new ArgumentException(serialization, nameof(serialization));
-            NrOfTestCasesInSuite = values[0];
-            NrOfTestCasesInExecutable = values[1];
+            NrOfTestCasesInSuite = int.Parse(fields[0]);
+            NrOfTestCasesInExecutable = int.Parse(fields[1]);
+            FullyQualifiedNameWithoutNamespace = fields[2];
         }
     }
 }

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -63,7 +63,17 @@ namespace GoogleTestAdapter.Runners
 
                         foreach (var testCase in groupedTestCases[executable])
                         {
-                            var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedName;
+                            string fullyQualifiedName = testCase.FullyQualifiedName;
+
+                            // If testCase contains a namespace then remove it because GoogleTest has no knowledge of namespaces.
+                            int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
+
+                            if (frequency > 1)
+                            {
+                                fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
+                            }
+
+                            var key = Path.GetFullPath(testCase.Source) + ":" + fullyQualifiedName;
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
                             if (_settings.TestPropertySettingsContainer.TryGetSettings(key, out settings)

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -180,24 +180,6 @@ namespace GoogleTestAdapter.Runners
         private IEnumerable<TestResult> TryRunTests(string executable, string workingDir, IDictionary<string, string> envVars, bool isBeingDebugged,
             IDebuggedProcessLauncher debuggedLauncher, CommandLineGenerator.Args arguments, IProcessExecutor executor, StreamingStandardOutputTestResultParser streamingParser)
         {
-            foreach (TestCase tc in arguments.TestCases)
-            {
-                // If namespace exists then remove it so we can compare the test display names.
-                //  Using just tc.DisplayName does not work for paramaterized test cases.
-                string fullyQualifiedName = tc.FullyQualifiedName;
-                int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
-                if (frequency > 1)
-                {
-                    string ns = fullyQualifiedName.Substring(0, fullyQualifiedName.IndexOf('.'));
-                    tc.Namespace = ns;
-                    _logger.LogInfo("NS removing: " + tc.Namespace);
-                    fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
-                }
-
-                tc.FullyQualifiedName = fullyQualifiedName;
-                _logger.LogInfo("Test Name after removing NS: " + tc.FullyQualifiedName);
-            }
-
             List<string> consoleOutput;
             if (_settings.UseNewTestExecutionFramework)
             {

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -63,17 +63,8 @@ namespace GoogleTestAdapter.Runners
 
                         foreach (var testCase in groupedTestCases[executable])
                         {
-                            string fullyQualifiedName = testCase.FullyQualifiedName;
+                            var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedName;
 
-                            // If testCase contains a namespace then remove it because GoogleTest has no knowledge of namespaces.
-                            int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
-
-                            if (frequency > 1)
-                            {
-                                fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
-                            }
-
-                            var key = Path.GetFullPath(testCase.Source) + ":" + fullyQualifiedName;
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
                             if (_settings.TestPropertySettingsContainer.TryGetSettings(key, out settings)

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -64,7 +64,6 @@ namespace GoogleTestAdapter.Runners
                         foreach (var testCase in groupedTestCases[executable])
                         {
                             var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedName;
-
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
                             if (_settings.TestPropertySettingsContainer.TryGetSettings(key, out settings)
@@ -181,6 +180,24 @@ namespace GoogleTestAdapter.Runners
         private IEnumerable<TestResult> TryRunTests(string executable, string workingDir, IDictionary<string, string> envVars, bool isBeingDebugged,
             IDebuggedProcessLauncher debuggedLauncher, CommandLineGenerator.Args arguments, IProcessExecutor executor, StreamingStandardOutputTestResultParser streamingParser)
         {
+            foreach (TestCase tc in arguments.TestCases)
+            {
+                // If namespace exists then remove it so we can compare the test display names.
+                //  Using just tc.DisplayName does not work for paramaterized test cases.
+                string fullyQualifiedName = tc.FullyQualifiedName;
+                int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
+                if (frequency > 1)
+                {
+                    string ns = fullyQualifiedName.Substring(0, fullyQualifiedName.IndexOf('.'));
+                    tc.Namespace = ns;
+                    _logger.LogInfo("NS removing: " + tc.Namespace);
+                    fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
+                }
+
+                tc.FullyQualifiedName = fullyQualifiedName;
+                _logger.LogInfo("Test Name after removing NS: " + tc.FullyQualifiedName);
+            }
+
             List<string> consoleOutput;
             if (_settings.UseNewTestExecutionFramework)
             {

--- a/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
@@ -87,7 +87,7 @@ namespace GoogleTestAdapter.TestCases
             {
                 foreach (var testCase in suiteTestCasesPair.Value)
                 {
-                    testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasesPair.Value.Count, testCases.Count));
+                    testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasesPair.Value.Count, testCases.Count, testCase.FullyQualifiedName));
                 }
             }
 
@@ -179,7 +179,7 @@ namespace GoogleTestAdapter.TestCases
                 {
                     foreach (var testCase in suiteTestCasesPair.Value)
                     {
-                        testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasesPair.Value.Count, testCases.Count));
+                        testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasesPair.Value.Count, testCases.Count, testCase.FullyQualifiedName));
                         reportTestCase?.Invoke(testCase);
                     }
                 }
@@ -232,7 +232,7 @@ namespace GoogleTestAdapter.TestCases
         private TestCase CreateTestCase(TestCaseDescriptor descriptor)
         {
             var testCase = new TestCase(
-                descriptor.FullyQualifiedName, _executable, descriptor.DisplayName, "", 0);
+                descriptor.FullyQualifiedName, descriptor.FullyQualifiedName, _executable, descriptor.DisplayName, "", 0);
             testCase.Traits.AddRange(GetFinalTraits(descriptor.DisplayName, new List<Trait>()));
             return testCase;
         }
@@ -259,14 +259,14 @@ namespace GoogleTestAdapter.TestCases
                     ns += ".";
 
                 var testCase = new TestCase(
-                    ns + descriptor.FullyQualifiedName, _executable, descriptor.DisplayName, location.Sourcefile, (int)location.Line);
+                    descriptor.FullyQualifiedName, ns + descriptor.FullyQualifiedName, _executable, descriptor.DisplayName, location.Sourcefile, (int)location.Line);
                 testCase.Traits.AddRange(GetFinalTraits(descriptor.DisplayName, location.Traits));
                 return testCase;
             }
 
             _logger.LogWarning(String.Format(Resources.LocationNotFoundError, descriptor.FullyQualifiedName));
             return new TestCase(
-                descriptor.FullyQualifiedName, _executable, descriptor.DisplayName, "", 0);
+                descriptor.FullyQualifiedName, descriptor.FullyQualifiedName, _executable, descriptor.DisplayName, "", 0);
         }
 
         internal static string GetTestSignatureNamespace(string signature)

--- a/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
@@ -196,24 +196,7 @@ namespace GoogleTestAdapter.TestResults
 
         public static TestCase FindTestcase(string qualifiedTestname, IList<TestCase> testCasesRun)
         {
-            foreach (TestCase tc in testCasesRun)
-            {
-                // If namespace exists then remove it so we can compare the test display names.
-                //  Using just tc.DisplayName does not work for paramaterized test cases.
-                string fullyQualifiedName = tc.FullyQualifiedName;
-                int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
-                if (frequency > 1)
-                {
-                    fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
-                }
-
-                if (fullyQualifiedName == qualifiedTestname)
-                {
-                    return tc;
-                }
-            }
-
-            return null;
+            return testCasesRun.SingleOrDefault(tc => tc.FullyQualifiedName == qualifiedTestname);
         }
 
         public static bool IsRunLine(string line)

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -229,24 +229,6 @@ namespace GoogleTestAdapter.TestAdapter
 
                 _executor = new GoogleTestExecutor(_logger, _settings);
             }
-            foreach (TestCase tc in testCasesToRun)
-            {
-                // If namespace exists then remove it so we can compare the test display names.
-                //  Using just tc.DisplayName does not work for paramaterized test cases.
-                string fullyQualifiedName = tc.FullyQualifiedName;
-                int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
-                if (frequency > 1)
-                {
-                    string ns = fullyQualifiedName.Substring(0, fullyQualifiedName.IndexOf('.'));
-                    tc.Namespace = ns;
-                    _logger.LogInfo("NS removing: " + tc.Namespace);
-                    fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
-                }
-
-                tc.FullyQualifiedName = fullyQualifiedName;
-                _logger.LogInfo("Test Name after removing NS: " + tc.FullyQualifiedName);
-            }
-
             _executor.RunTests(testCasesToRun, reporter, launcher,
                 runContext.IsBeingDebugged, runContext.SolutionDirectory, processExecutor);
             reporter.AllTestsFinished();

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -229,6 +229,20 @@ namespace GoogleTestAdapter.TestAdapter
 
                 _executor = new GoogleTestExecutor(_logger, _settings);
             }
+            foreach (TestCase tc in testCasesToRun)
+            {
+                // If namespace exists then remove it so we can compare the test display names.
+                //  Using just tc.DisplayName does not work for paramaterized test cases.
+                string fullyQualifiedName = tc.FullyQualifiedName;
+                int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
+                if (frequency > 1)
+                {
+                    fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
+                }
+
+                tc.FullyQualifiedName = fullyQualifiedName;
+            }
+
             _executor.RunTests(testCasesToRun, reporter, launcher,
                 runContext.IsBeingDebugged, runContext.SolutionDirectory, processExecutor);
             reporter.AllTestsFinished();

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -98,7 +98,7 @@ namespace GoogleTestAdapter.TestAdapter
                 filter.Filter(allTestCasesInExecutables.Select(tc => tc.ToVsTestCase())).ToList();
             ICollection<TestCase> testCasesToRun =
                 allTestCasesInExecutables.Where(
-                    tc => vsTestCasesToRun.Any(vtc => tc.FullyQualifiedName == vtc.FullyQualifiedName)).ToArray();
+                    tc => vsTestCasesToRun.Any(vtc => tc.FullyQualifiedNameWithNamespace == vtc.FullyQualifiedName)).ToArray();
 
             DoRunTests(testCasesToRun, runContext, frameworkHandle);
 

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -237,10 +237,14 @@ namespace GoogleTestAdapter.TestAdapter
                 int frequency = fullyQualifiedName.Where(x => (x == '.')).Count();
                 if (frequency > 1)
                 {
+                    string ns = fullyQualifiedName.Substring(0, fullyQualifiedName.IndexOf('.'));
+                    tc.Namespace = ns;
+                    _logger.LogInfo("NS removing: " + tc.Namespace);
                     fullyQualifiedName = fullyQualifiedName.Substring(fullyQualifiedName.IndexOf('.') + 1);
                 }
 
                 tc.FullyQualifiedName = fullyQualifiedName;
+                _logger.LogInfo("Test Name after removing NS: " + tc.FullyQualifiedName);
             }
 
             _executor.RunTests(testCasesToRun, reporter, launcher,

--- a/GoogleTestAdapter/Tests.Common/TestDataCreator.cs
+++ b/GoogleTestAdapter/Tests.Common/TestDataCreator.cs
@@ -70,7 +70,7 @@ namespace GoogleTestAdapter.Tests.Common
 
         public TestCase ToTestCase(string name, string executable, string sourceFile = "")
         {
-            return new TestCase(name, executable, name, sourceFile, 0);
+            return new TestCase(name, name,executable, name, sourceFile, 0);
         }
 
         public TestCase ToTestCase(string name)
@@ -109,7 +109,7 @@ namespace GoogleTestAdapter.Tests.Common
                 {
                     if (qualifiedNamesToRun.Contains(testCase.FullyQualifiedName))
                     {
-                        testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasePair.Value.Count, allQualifiedNames.Length));
+                        testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasePair.Value.Count, allQualifiedNames.Length, testCase.FullyQualifiedName));
                         testCases.Add(testCase);
                     }
                 }


### PR DESCRIPTION
Change functionality to use FullyQualifiedNameWithoutNamespace and FullyQualifiedName. Google test framework has no knowledge of namespaces so need to be removed to run tests. However, the test explorer needs namespaces to display the hierarchy.
Note: It is understood that the naming of these variables can be a bit confusing. A future PR is planned to address this issue once the vsix changes can be tested (this bug is blocking all vsix installations at the moment: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1844871).