### PR TITLE
Change some variable names

### DIFF
--- a/GoogleTestAdapter/Core.Tests/GoogleTestDiscovererTests.cs
+++ b/GoogleTestAdapter/Core.Tests/GoogleTestDiscovererTests.cs
@@ -283,7 +283,7 @@ namespace GoogleTestAdapter
                 testCase.LineNumber.Should().Be(0);
                 testCase.Source.Should().Be(TestResources.Tests_DebugX86);
                 testCase.DisplayName.Should().NotBeNullOrEmpty();
-                testCase.FullyQualifiedName.Should().NotBeNullOrEmpty();
+                testCase.FullyQualifiedNameWithoutNamespace.Should().NotBeNullOrEmpty();
             }
         }
 
@@ -309,8 +309,8 @@ namespace GoogleTestAdapter
             discoverer.DiscoverTests(TestResources.TestDiscoveryParamExe.Yield(), MockFrameworkReporter.Object);
 
             testCases.Count.Should().Be(2);
-            testCases.Should().Contain(t => t.FullyQualifiedName == "TestDiscovery.TestFails");
-            testCases.Should().Contain(t => t.FullyQualifiedName == "TestDiscovery.TestPasses");
+            testCases.Should().Contain(t => t.FullyQualifiedNameWithoutNamespace == "TestDiscovery.TestFails");
+            testCases.Should().Contain(t => t.FullyQualifiedNameWithoutNamespace == "TestDiscovery.TestPasses");
         }
 
         [TestMethod]
@@ -323,8 +323,8 @@ namespace GoogleTestAdapter
             IList<TestCase> testCases = discoverer.GetTestsFromExecutable(TestResources.TestDiscoveryParamExe);
 
             testCases.Count.Should().Be(2);
-            testCases.Should().Contain(t => t.FullyQualifiedName == "TestDiscovery.TestFails");
-            testCases.Should().Contain(t => t.FullyQualifiedName == "TestDiscovery.TestPasses");
+            testCases.Should().Contain(t => t.FullyQualifiedNameWithoutNamespace == "TestDiscovery.TestFails");
+            testCases.Should().Contain(t => t.FullyQualifiedNameWithoutNamespace == "TestDiscovery.TestPasses");
         }
 
         [TestMethod]
@@ -338,7 +338,7 @@ namespace GoogleTestAdapter
             for (int i = 0; i < 5000; i++)
             {
                 string fullyQualifiedName = $"LoadTests.Test/{i}";
-                bool contains = testCases.Any(tc => tc.FullyQualifiedName == fullyQualifiedName);
+                bool contains = testCases.Any(tc => tc.FullyQualifiedNameWithoutNamespace == fullyQualifiedName);
                 contains.Should().BeTrue($" Test not found: {fullyQualifiedName}");
             }
         }
@@ -374,12 +374,12 @@ namespace GoogleTestAdapter
 
             testCases.Count.Should().Be(TestResources.NrOfTests);
 
-            TestCase testCase = testCases.Single(tc => tc.FullyQualifiedName == "TheFixture.AddFails");
+            TestCase testCase = testCases.Single(tc => tc.FullyQualifiedNameWithoutNamespace == "TheFixture.AddFails");
             testCase.DisplayName.Should().Be("TheFixture.AddFails");
             testCase.CodeFilePath.Should().EndWith(@"sampletests\tests\fixturetests.cpp");
             testCase.LineNumber.Should().Be(11);
 
-            testCase = testCases.Single(tc => tc.FullyQualifiedName == "Arr/TypeParameterizedTests/1.CanDefeatMath");
+            testCase = testCases.Single(tc => tc.FullyQualifiedNameWithoutNamespace == "Arr/TypeParameterizedTests/1.CanDefeatMath");
             testCase.DisplayName.Should().Be("Arr/TypeParameterizedTests/1.CanDefeatMath<MyStrangeArray>");
             testCase.CodeFilePath.Should().EndWith(@"sampletests\tests\typeparameterizedtests.cpp");
             testCase.LineNumber.Should().Be(53);
@@ -416,7 +416,7 @@ namespace GoogleTestAdapter
             var discoverer = new GoogleTestDiscoverer(TestEnvironment.Logger, TestEnvironment.Options);
             IList<TestCase> tests = discoverer.GetTestsFromExecutable(TestResources.Tests_DebugX86);
 
-            TestCase testCase = tests.Single(t => t.FullyQualifiedName == fullyQualifiedName);
+            TestCase testCase = tests.Single(t => t.FullyQualifiedNameWithoutNamespace == fullyQualifiedName);
             testCase.DisplayName.Should().MatchRegex(displayNameRegex.ToString());
         }
 

--- a/GoogleTestAdapter/Core.Tests/Scheduling/DurationBasedTestsSplitterTests.cs
+++ b/GoogleTestAdapter/Core.Tests/Scheduling/DurationBasedTestsSplitterTests.cs
@@ -28,7 +28,7 @@ namespace GoogleTestAdapter.Scheduling
 
             result.Count.Should().Be(2);
             result[0].Count.Should().Be(1);
-            result[0][0].FullyQualifiedName.Should().Be("LongTest");
+            result[0][0].FullyQualifiedNameWithoutNamespace.Should().Be("LongTest");
             result[1].Count.Should().Be(3);
         }
 
@@ -49,7 +49,7 @@ namespace GoogleTestAdapter.Scheduling
 
             result.Count.Should().Be(3);
             result[0].Count.Should().Be(1);
-            result[0][0].FullyQualifiedName.Should().Be("LongTest");
+            result[0][0].FullyQualifiedNameWithoutNamespace.Should().Be("LongTest");
             result[1].Count.Should().Be(2);
             result[2].Count.Should().Be(1);
         }
@@ -69,7 +69,7 @@ namespace GoogleTestAdapter.Scheduling
 
             result.Count.Should().Be(2);
             result[0].Count.Should().Be(1);
-            result[0][0].FullyQualifiedName.Should().Be("LongTest");
+            result[0][0].FullyQualifiedNameWithoutNamespace.Should().Be("LongTest");
             result[1].Count.Should().Be(1);
         }
 

--- a/GoogleTestAdapter/Core.Tests/TestCases/TestCaseFactoryTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestCases/TestCaseFactoryTests.cs
@@ -48,8 +48,8 @@ namespace GoogleTestAdapter.TestCases
             var returnedTestCases = factory.CreateTestCases(testCase => reportedTestCases.Add(testCase));
 
             reportedTestCases.Count.Should().Be(2);
-            reportedTestCases.Should().Contain(t => t.FullyQualifiedName == "TestDiscovery.TestFails");
-            reportedTestCases.Should().Contain(t => t.FullyQualifiedName == "TestDiscovery.TestPasses");
+            reportedTestCases.Should().Contain(t => t.FullyQualifiedNameWithoutNamespace == "TestDiscovery.TestFails");
+            reportedTestCases.Should().Contain(t => t.FullyQualifiedNameWithoutNamespace == "TestDiscovery.TestPasses");
         }
 
     }

--- a/GoogleTestAdapter/Core.Tests/TestResults/StandardOutputTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/StandardOutputTestResultParserTests.cs
@@ -143,7 +143,7 @@ namespace GoogleTestAdapter.TestResults
 
             results.Count.Should().Be(3);
 
-            results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddFails");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddFails");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[0]);
             results[0].ErrorMessage.Should().NotContain(StandardOutputTestResultParser.CrashText);
             results[0].Duration.Should().Be(TimeSpan.FromMilliseconds(3));
@@ -151,11 +151,11 @@ namespace GoogleTestAdapter.TestResults
                 .Contain(
                     @"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp");
 
-            results[1].TestCase.FullyQualifiedName.Should().Be("TestMath.AddPasses");
+            results[1].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddPasses");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[1]);
             results[1].Duration.Should().Be(StandardOutputTestResultParser.ShortTestDuration);
 
-            results[2].TestCase.FullyQualifiedName.Should().Be("TestMath.Crash");
+            results[2].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.Crash");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[2]);
             results[2].ErrorMessage.Should().NotContain(StandardOutputTestResultParser.CrashText);
             results[2].Duration.Should().Be(TimeSpan.FromMilliseconds(9));
@@ -169,13 +169,13 @@ namespace GoogleTestAdapter.TestResults
 
             results.Count.Should().Be(2);
 
-            results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddFails");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddFails");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[0]);
             results[0].ErrorMessage.Should().NotContain(StandardOutputTestResultParser.CrashText);
             results[0].Duration.Should().Be(TimeSpan.FromMilliseconds(3));
             results[0].ErrorStackTrace.Should().Contain(@"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp");
 
-            results[1].TestCase.FullyQualifiedName.Should().Be("TestMath.AddPasses");
+            results[1].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddPasses");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[1]);
             results[1].ErrorMessage.Should().Contain(StandardOutputTestResultParser.CrashText);
             results[1].ErrorMessage.Should().NotContain("Test output:");
@@ -190,17 +190,17 @@ namespace GoogleTestAdapter.TestResults
 
             results.Count.Should().Be(3);
 
-            results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddFails");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddFails");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[0]);
             results[0].ErrorMessage.Should().NotContain(StandardOutputTestResultParser.CrashText);
             results[0].Duration.Should().Be(TimeSpan.FromMilliseconds(3));
             results[0].ErrorStackTrace.Should().Contain(@"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp");
 
-            results[1].TestCase.FullyQualifiedName.Should().Be("TestMath.AddPasses");
+            results[1].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddPasses");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[1]);
             results[1].Duration.Should().Be(StandardOutputTestResultParser.ShortTestDuration);
 
-            results[2].TestCase.FullyQualifiedName.Should().Be("TestMath.Crash");
+            results[2].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.Crash");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[2]);
             results[2].ErrorMessage.Should().Contain(StandardOutputTestResultParser.CrashText);
             results[2].ErrorMessage.Should().Contain("Test output:");
@@ -215,7 +215,7 @@ namespace GoogleTestAdapter.TestResults
             List<TestResult> results = ComputeTestResults(WrongDurationUnit);
 
             results.Count.Should().Be(1);
-            results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddFails");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddFails");
             results[0].Duration.Should().Be(TimeSpan.FromMilliseconds(1));
             results[0].ErrorStackTrace.Should().Contain(@"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp");
 
@@ -234,7 +234,7 @@ namespace GoogleTestAdapter.TestResults
                 List<TestResult> results = ComputeTestResults(ThousandsSeparatorInDuration);
 
                 results.Count.Should().Be(1);
-                results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddFails");
+                results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddFails");
                 results[0].Duration.Should().Be(TimeSpan.FromMilliseconds(4656));
             }
             finally
@@ -250,7 +250,7 @@ namespace GoogleTestAdapter.TestResults
             List<TestResult> results = ComputeTestResults(PassingTestProducesConsoleOutput);
 
             results.Count.Should().Be(1);
-            results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddPasses");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddPasses");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[0]);
         }
 
@@ -270,9 +270,9 @@ namespace GoogleTestAdapter.TestResults
                 .GetTestResults();
 
             results.Count.Should().Be(2);
-            results[0].TestCase.FullyQualifiedName.Should().Be("Test.AB");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("Test.AB");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[0]);
-            results[1].TestCase.FullyQualifiedName.Should().Be("Test.A");
+            results[1].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("Test.A");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[1]);
         }
 

--- a/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
@@ -163,7 +163,7 @@ namespace GoogleTestAdapter.TestResults
 
             results.Count.Should().Be(3);
 
-            results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddFails");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddFails");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[0]);
             results[0].ErrorMessage.Should().NotContain(StandardOutputTestResultParser.CrashText);
             results[0].Duration.Should().Be(TimeSpan.FromMilliseconds(3));
@@ -171,11 +171,11 @@ namespace GoogleTestAdapter.TestResults
                 .Contain(
                     @"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp");
 
-            results[1].TestCase.FullyQualifiedName.Should().Be("TestMath.AddPasses");
+            results[1].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddPasses");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[1]);
             results[1].Duration.Should().Be(StandardOutputTestResultParser.ShortTestDuration);
 
-            results[2].TestCase.FullyQualifiedName.Should().Be("TestMath.Crash");
+            results[2].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.Crash");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[2]);
             results[2].ErrorMessage.Should().NotContain(StandardOutputTestResultParser.CrashText);
             results[2].Duration.Should().Be(TimeSpan.FromMilliseconds(9));
@@ -189,13 +189,13 @@ namespace GoogleTestAdapter.TestResults
 
             results.Count.Should().Be(2);
 
-            results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddFails");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddFails");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[0]);
             results[0].ErrorMessage.Should().NotContain(StandardOutputTestResultParser.CrashText);
             results[0].Duration.Should().Be(TimeSpan.FromMilliseconds(3));
             results[0].ErrorStackTrace.Should().Contain(@"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp");
 
-            results[1].TestCase.FullyQualifiedName.Should().Be("TestMath.AddPasses");
+            results[1].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddPasses");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[1]);
             results[1].ErrorMessage.Should().Contain(StandardOutputTestResultParser.CrashText);
             results[1].ErrorMessage.Should().NotContain("Test output:");
@@ -210,17 +210,17 @@ namespace GoogleTestAdapter.TestResults
 
             results.Count.Should().Be(3);
 
-            results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddFails");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddFails");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[0]);
             results[0].ErrorMessage.Should().NotContain(StandardOutputTestResultParser.CrashText);
             results[0].Duration.Should().Be(TimeSpan.FromMilliseconds(3));
             results[0].ErrorStackTrace.Should().Contain(@"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp");
 
-            results[1].TestCase.FullyQualifiedName.Should().Be("TestMath.AddPasses");
+            results[1].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddPasses");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[1]);
             results[1].Duration.Should().Be(StandardOutputTestResultParser.ShortTestDuration);
 
-            results[2].TestCase.FullyQualifiedName.Should().Be("TestMath.Crash");
+            results[2].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.Crash");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[2]);
             results[2].ErrorMessage.Should().Contain(StandardOutputTestResultParser.CrashText);
             results[2].ErrorMessage.Should().Contain("Test output:");
@@ -236,7 +236,7 @@ namespace GoogleTestAdapter.TestResults
 
             results.Count.Should().Be(3);
 
-            results[1].TestCase.FullyQualifiedName.Should().Be("TestMath.AddPasses");
+            results[1].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddPasses");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[1]);
             results[1].Duration.Should().Be(StandardOutputTestResultParser.ShortTestDuration);
         }
@@ -249,7 +249,7 @@ namespace GoogleTestAdapter.TestResults
 
             results.Count.Should().Be(3);
 
-            results[1].TestCase.FullyQualifiedName.Should().Be("TestMath.AddPasses");
+            results[1].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddPasses");
             XmlTestResultParserTests.AssertTestResultIsFailure(results[1]);
             results[1].ErrorMessage.Should().Contain("DummyOutput");
             results[1].Duration.Should().Be(StandardOutputTestResultParser.ShortTestDuration);
@@ -262,7 +262,7 @@ namespace GoogleTestAdapter.TestResults
             IList<TestResult> results = ComputeTestResults(WrongDurationUnit);
 
             results.Count.Should().Be(1);
-            results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddFails");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddFails");
             results[0].Duration.Should().Be(TimeSpan.FromMilliseconds(1));
             results[0].ErrorStackTrace.Should().Contain(@"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp");
 
@@ -281,7 +281,7 @@ namespace GoogleTestAdapter.TestResults
                 IList<TestResult> results = ComputeTestResults(ThousandsSeparatorInDuration);
 
                 results.Count.Should().Be(1);
-                results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddFails");
+                results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddFails");
                 results[0].Duration.Should().Be(TimeSpan.FromMilliseconds(4656));
             }
             finally
@@ -297,7 +297,7 @@ namespace GoogleTestAdapter.TestResults
             IList<TestResult> results = ComputeTestResults(PassingTestProducesConsoleOutput);
 
             results.Count.Should().Be(1);
-            results[0].TestCase.FullyQualifiedName.Should().Be("TestMath.AddPasses");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("TestMath.AddPasses");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[0]);
         }
 
@@ -317,9 +317,9 @@ namespace GoogleTestAdapter.TestResults
                 .GetTestResults();
 
             results.Count.Should().Be(2);
-            results[0].TestCase.FullyQualifiedName.Should().Be("Test.AB");
+            results[0].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("Test.AB");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[0]);
-            results[1].TestCase.FullyQualifiedName.Should().Be("Test.A");
+            results[1].TestCase.FullyQualifiedNameWithoutNamespace.Should().Be("Test.A");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[1]);
         }
 

--- a/GoogleTestAdapter/Core/Model/TestCase.cs
+++ b/GoogleTestAdapter/Core/Model/TestCase.cs
@@ -6,8 +6,8 @@ namespace GoogleTestAdapter.Model
     {
         public string Source { get; }
 
+        public string FullyQualifiedNameWithoutNamespace { get; }
         public string FullyQualifiedName { get; }
-        public string FullyQualifiedNameWithNamespace { get; }
         public string DisplayName { get; }
 
         public string CodeFilePath { get; }
@@ -16,10 +16,10 @@ namespace GoogleTestAdapter.Model
         public List<Trait> Traits { get; } = new List<Trait>();
         public List<TestProperty> Properties { get; } = new List<TestProperty>();
 
-        public TestCase(string fullyQualifiedName, string fullyQualifiedNameWithNamespace, string source, string displayName, string codeFilePath, int lineNumber)
+        public TestCase(string fullyQualifiedNameWithoutNamespace, string fullyQualifiedName, string source, string displayName, string codeFilePath, int lineNumber)
         {
+            FullyQualifiedNameWithoutNamespace = fullyQualifiedNameWithoutNamespace;
             FullyQualifiedName = fullyQualifiedName;
-            FullyQualifiedNameWithNamespace = fullyQualifiedNameWithNamespace;
             Source = source;
             DisplayName = displayName;
             CodeFilePath = codeFilePath;
@@ -33,13 +33,13 @@ namespace GoogleTestAdapter.Model
             if (other == null)
                 return false;
 
-            return FullyQualifiedName == other.FullyQualifiedName && Source == other.Source;
+            return FullyQualifiedNameWithoutNamespace == other.FullyQualifiedNameWithoutNamespace && Source == other.Source;
         }
 
         public override int GetHashCode()
         {
             int hash = 17;
-            hash = hash * 31 + FullyQualifiedName.GetHashCode();
+            hash = hash * 31 + FullyQualifiedNameWithoutNamespace.GetHashCode();
             hash = hash * 31 + Source.GetHashCode();
             return hash;
         }

--- a/GoogleTestAdapter/Core/Runners/CommandLineGenerator.cs
+++ b/GoogleTestAdapter/Core/Runners/CommandLineGenerator.cs
@@ -113,7 +113,7 @@ namespace GoogleTestAdapter.Runners
             }
 
             string result = "";
-            string nextTest = testCases[0].FullyQualifiedName;
+            string nextTest = testCases[0].FullyQualifiedNameWithoutNamespace;
             if (nextTest.Length > maxLength)
             {
                 throw new Exception(String.Format(Resources.CommandLineGeneratorError, maxLength, includedTestCases.Count, nextTest.Length));
@@ -126,7 +126,7 @@ namespace GoogleTestAdapter.Runners
                 testCases.RemoveAt(0);
                 if (testCases.Count > 0)
                 {
-                    nextTest = ":" + testCases[0].FullyQualifiedName;
+                    nextTest = ":" + testCases[0].FullyQualifiedNameWithoutNamespace;
                 }
             }
             return result;
@@ -247,7 +247,7 @@ namespace GoogleTestAdapter.Runners
 
         private string GetTestsuiteName(TestCase testCase)
         {
-            return testCase.FullyQualifiedName.Split('.')[0];
+            return testCase.FullyQualifiedNameWithoutNamespace.Split('.')[0];
         }
 
     }

--- a/GoogleTestAdapter/Core/Runners/ParallelTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/ParallelTestRunner.cs
@@ -98,7 +98,7 @@ namespace GoogleTestAdapter.Runners
                 foreach (KeyValuePair<TestCase, int> duration in durations)
                 {
                     if (!_schedulingAnalyzer.AddExpectedDuration(duration.Key, duration.Value))
-                        _logger.DebugWarning(String.Format(Resources.TestCaseInAnalyzer, duration.Key.FullyQualifiedName));
+                        _logger.DebugWarning(String.Format(Resources.TestCaseInAnalyzer, duration.Key.FullyQualifiedNameWithoutNamespace));
                 }
             }
             catch (InvalidTestDurationsException e)

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -63,7 +63,7 @@ namespace GoogleTestAdapter.Runners
 
                         foreach (var testCase in groupedTestCases[executable])
                         {
-                            var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedName;
+                            var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedNameWithoutNamespace;
                             ITestPropertySettings settings;
                             // Tests with default settings are treated as not having settings and can be run together
                             if (_settings.TestPropertySettingsContainer.TryGetSettings(key, out settings)
@@ -150,7 +150,7 @@ namespace GoogleTestAdapter.Runners
                 foreach (TestResult result in results)
                 {
                     if (!_schedulingAnalyzer.AddActualDuration(result.TestCase, (int)result.Duration.TotalMilliseconds))
-                        _logger.DebugWarning(String.Format(Resources.TestCaseInAnalyzer, result.TestCase.FullyQualifiedName));
+                        _logger.DebugWarning(String.Format(Resources.TestCaseInAnalyzer, result.TestCase.FullyQualifiedNameWithoutNamespace));
                 }
             }
         }
@@ -199,7 +199,7 @@ namespace GoogleTestAdapter.Runners
                 arguments.TestCases.Except(streamingParser.TestResults.Select(tr => tr.TestCase));
             var testResults = new TestResultCollector(_logger, _threadName)
                 .CollectTestResults(remainingTestCases, consoleOutput, streamingParser.CrashedTestCase);
-            testResults = testResults.OrderBy(tr => tr.TestCase.FullyQualifiedName).ToList();
+            testResults = testResults.OrderBy(tr => tr.TestCase.FullyQualifiedNameWithoutNamespace).ToList();
 
             return testResults;
         }
@@ -247,7 +247,7 @@ namespace GoogleTestAdapter.Runners
             foreach (TestResult result in streamingParser.TestResults)
             {
                 if (!_schedulingAnalyzer.AddActualDuration(result.TestCase, (int) result.Duration.TotalMilliseconds))
-                    _logger.LogWarning(String.Format(Resources.AlreadyInAnalyzer, _threadName, result.TestCase.FullyQualifiedName));
+                    _logger.LogWarning(String.Format(Resources.AlreadyInAnalyzer, _threadName, result.TestCase.FullyQualifiedNameWithoutNamespace));
             }
             return consoleOutput;
         }

--- a/GoogleTestAdapter/Core/Runners/TestResultCollector.cs
+++ b/GoogleTestAdapter/Core/Runners/TestResultCollector.cs
@@ -35,7 +35,7 @@ namespace GoogleTestAdapter.Runners
                     crashedTestCase = consoleParser.CrashedTestCase;
 
                 var remainingTestCases = arrTestCasesRun
-                    .Where(tc => !testResults.Exists(tr => tr.TestCase.FullyQualifiedName == tc.FullyQualifiedName))
+                    .Where(tc => !testResults.Exists(tr => tr.TestCase.FullyQualifiedNameWithoutNamespace == tc.FullyQualifiedNameWithoutNamespace))
                     .ToArray();
 
                 if (crashedTestCase != null)
@@ -52,7 +52,7 @@ namespace GoogleTestAdapter.Runners
             List<TestResult> consoleResults = consoleParser.GetTestResults();
             int nrOfCollectedTestResults = 0;
             foreach (TestResult testResult in consoleResults.Where(
-                tr => !testResults.Exists(tr2 => tr.TestCase.FullyQualifiedName == tr2.TestCase.FullyQualifiedName)))
+                tr => !testResults.Exists(tr2 => tr.TestCase.FullyQualifiedNameWithoutNamespace == tr2.TestCase.FullyQualifiedNameWithoutNamespace)))
             {
                 testResults.Add(testResult);
                 nrOfCollectedTestResults++;

--- a/GoogleTestAdapter/Core/Scheduling/SchedulingAnalyzer.cs
+++ b/GoogleTestAdapter/Core/Scheduling/SchedulingAnalyzer.cs
@@ -73,7 +73,7 @@ namespace GoogleTestAdapter.Scheduling
             _logger.DebugInfo(String.Format(Resources.WorstDifferences, nrOfWorstDifferences));
             for (int i = 0; i < nrOfWorstDifferences; i++)
             {
-                _logger.DebugInfo(String.Format(Resources.Results, differences[i].TestCase.FullyQualifiedName, ExpectedTestcaseDurations[differences[i].TestCase], ActualTestcaseDurations[differences[i].TestCase]));
+                _logger.DebugInfo(String.Format(Resources.Results, differences[i].TestCase.FullyQualifiedNameWithoutNamespace, ExpectedTestcaseDurations[differences[i].TestCase], ActualTestcaseDurations[differences[i].TestCase]));
             }
         }
 

--- a/GoogleTestAdapter/Core/Scheduling/TestDurationSerializer.cs
+++ b/GoogleTestAdapter/Core/Scheduling/TestDurationSerializer.cs
@@ -103,7 +103,7 @@ namespace GoogleTestAdapter.Scheduling
             foreach (TestCase testcase in testcases)
             {
                 TestDuration pair;
-                if (durationsMap.TryGetValue(testcase.FullyQualifiedName, out pair))
+                if (durationsMap.TryGetValue(testcase.FullyQualifiedNameWithoutNamespace, out pair))
                     durations.Add(testcase, pair.Duration);
             }
 
@@ -131,8 +131,8 @@ namespace GoogleTestAdapter.Scheduling
             foreach (TestResult testResult in 
                 testresults.Where(tr => tr.Outcome == TestOutcome.Passed || tr.Outcome == TestOutcome.Failed))
             {
-                durations[testResult.TestCase.FullyQualifiedName] =
-                    new TestDuration(testResult.TestCase.FullyQualifiedName, GetDuration(testResult));
+                durations[testResult.TestCase.FullyQualifiedNameWithoutNamespace] =
+                    new TestDuration(testResult.TestCase.FullyQualifiedNameWithoutNamespace, GetDuration(testResult));
             }
 
             container.TestDurations.Clear();

--- a/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
@@ -87,7 +87,7 @@ namespace GoogleTestAdapter.TestCases
             {
                 foreach (var testCase in suiteTestCasesPair.Value)
                 {
-                    testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasesPair.Value.Count, testCases.Count, testCase.FullyQualifiedName));
+                    testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasesPair.Value.Count, testCases.Count, testCase.FullyQualifiedNameWithoutNamespace));
                 }
             }
 
@@ -179,7 +179,7 @@ namespace GoogleTestAdapter.TestCases
                 {
                     foreach (var testCase in suiteTestCasesPair.Value)
                     {
-                        testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasesPair.Value.Count, testCases.Count, testCase.FullyQualifiedName));
+                        testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasesPair.Value.Count, testCases.Count, testCase.FullyQualifiedNameWithoutNamespace));
                         reportTestCase?.Invoke(testCase);
                     }
                 }

--- a/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
@@ -196,7 +196,7 @@ namespace GoogleTestAdapter.TestResults
 
         public static TestCase FindTestcase(string qualifiedTestname, IList<TestCase> testCasesRun)
         {
-            return testCasesRun.SingleOrDefault(tc => tc.FullyQualifiedName == qualifiedTestname);
+            return testCasesRun.SingleOrDefault(tc => tc.FullyQualifiedNameWithoutNamespace == qualifiedTestname);
         }
 
         public static bool IsRunLine(string line)

--- a/GoogleTestAdapter/Core/TestResults/XmlTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/XmlTestResultParser.cs
@@ -26,7 +26,7 @@ namespace GoogleTestAdapter.TestResults
         {
             _logger = logger;
             _xmlResultFile = xmlResultFile;
-            _testCasesMap = testCasesRun.ToDictionary(tc => tc.FullyQualifiedName, tc => tc);
+            _testCasesMap = testCasesRun.ToDictionary(tc => tc.FullyQualifiedNameWithoutNamespace, tc => tc);
         }
 
 

--- a/GoogleTestAdapter/TestAdapter/DataConversionExtensions.cs
+++ b/GoogleTestAdapter/TestAdapter/DataConversionExtensions.cs
@@ -51,7 +51,7 @@ namespace GoogleTestAdapter.TestAdapter
 
         public static VsTestCase ToVsTestCase(this TestCase testCase)
         {
-            var vsTestCase = new VsTestCase(testCase.FullyQualifiedNameWithNamespace, TestExecutor.ExecutorUri, testCase.Source)
+            var vsTestCase = new VsTestCase(testCase.FullyQualifiedName, TestExecutor.ExecutorUri, testCase.Source)
             {
                 DisplayName = testCase.DisplayName,
                 CodeFilePath = testCase.CodeFilePath,

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -98,7 +98,7 @@ namespace GoogleTestAdapter.TestAdapter
                 filter.Filter(allTestCasesInExecutables.Select(tc => tc.ToVsTestCase())).ToList();
             ICollection<TestCase> testCasesToRun =
                 allTestCasesInExecutables.Where(
-                    tc => vsTestCasesToRun.Any(vtc => tc.FullyQualifiedNameWithNamespace == vtc.FullyQualifiedName)).ToArray();
+                    tc => vsTestCasesToRun.Any(vtc => tc.FullyQualifiedName == vtc.FullyQualifiedName)).ToArray();
 
             DoRunTests(testCasesToRun, runContext, frameworkHandle);
 

--- a/GoogleTestAdapter/Tests.Common/TestDataCreator.cs
+++ b/GoogleTestAdapter/Tests.Common/TestDataCreator.cs
@@ -64,7 +64,7 @@ namespace GoogleTestAdapter.Tests.Common
         {
             return AllTestCasesExceptLoadTests.Where(
                 testCase => qualifiedNames.Any(
-                    qualifiedName => testCase.FullyQualifiedName.Contains(qualifiedName)))
+                    qualifiedName => testCase.FullyQualifiedNameWithoutNamespace.Contains(qualifiedName)))
                     .ToList();
         }
 
@@ -107,9 +107,9 @@ namespace GoogleTestAdapter.Tests.Common
             {
                 foreach (var testCase in suiteTestCasePair.Value)
                 {
-                    if (qualifiedNamesToRun.Contains(testCase.FullyQualifiedName))
+                    if (qualifiedNamesToRun.Contains(testCase.FullyQualifiedNameWithoutNamespace))
                     {
-                        testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasePair.Value.Count, allQualifiedNames.Length, testCase.FullyQualifiedName));
+                        testCase.Properties.Add(new TestCaseMetaDataProperty(suiteTestCasePair.Value.Count, allQualifiedNames.Length, testCase.FullyQualifiedNameWithoutNamespace));
                         testCases.Add(testCase);
                     }
                 }


### PR DESCRIPTION
Note: This PR only contains variable name changes.
Instead of using FQNWithNS we use FQNWithoutNS and FQN. This makes more logical sense since a FQN is supposed to contain a NS anyways.