### PR TITLE
Change the conditions to switch the Google Test libraries to link

### DIFF
--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
@@ -28,6 +28,18 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="Shared" />

--- a/GoogleTestNuGet/googletest.targets.tt
+++ b/GoogleTestNuGet/googletest.targets.tt
@@ -16,28 +16,28 @@
   </ItemGroup>
   <ItemDefinitionGroup Condition="'$(Disable-<#= PackageNameDashes #>)' == ''">
     <Link>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'x64' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Release\gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'x64' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Release\gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86') And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86') And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Debug\gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm64' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Debug\gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Release\gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'arm64' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Release\gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Debug\gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Debug\gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'arm'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Release\gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'arm' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Release\gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' == 'true' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' == 'true' And '$(Platform)' == 'x64' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' != 'true' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Release\gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' != 'true' And '$(Platform)' == 'x64' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Release\gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' == 'true' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' == 'true' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86') And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' != 'true' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' != 'true' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86') And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' == 'true' And '$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Debug\gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' == 'true' And '$(Platform)' == 'arm64' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Debug\gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' != 'true' And '$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Release\gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' != 'true' And '$(Platform)' == 'arm64' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Release\gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' == 'true' And '$(Platform)' == 'arm'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Debug\gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' == 'true' And '$(Platform)' == 'arm' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Debug\gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' != 'true' And '$(Platform)' == 'arm'">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Release\gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseDebugLibraries)' != 'true' And '$(Platform)' == 'arm' And '$(Microsoft-GoogleTest-Disable-gtest_main)' == ''">$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Release\gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'x64' And '$(Disable-<#= PackageNameDashes #>)' == ''">
+  <ItemGroup Condition="'$(UseDebugLibraries)' == 'true' And '$(Platform)' == 'x64' And '$(Disable-<#= PackageNameDashes #>)' == ''">
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtestd.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtest_maind.dll" Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" />
@@ -48,7 +48,7 @@
       <ReferenceCopyLocalPaths Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Debug\gtest_main.pdb" />
     <# } #>
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'x64' And '$(Disable-<#= PackageNameDashes #>)' == ''">
+  <ItemGroup Condition="'$(UseDebugLibraries)' != 'true' And '$(Platform)' == 'x64' And '$(Disable-<#= PackageNameDashes #>)' == ''">
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Release\gtest.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Release\gtest_main.dll" Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" />
@@ -56,7 +56,7 @@
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Release\gtest.pdb" />
       <ReferenceCopyLocalPaths Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x64\Release\gtest_main.pdb" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86') And '$(Disable-<#= PackageNameDashes #>)' == ''">
+  <ItemGroup Condition="'$(UseDebugLibraries)' == 'true' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86') And '$(Disable-<#= PackageNameDashes #>)' == ''">
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtestd.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtest_maind.dll" Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" />
@@ -67,7 +67,7 @@
       <ReferenceCopyLocalPaths Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Debug\gtest_main.pdb" />
     <# } #>
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86') And '$(Disable-<#= PackageNameDashes #>)' == ''">
+  <ItemGroup Condition="'$(UseDebugLibraries)' != 'true' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86') And '$(Disable-<#= PackageNameDashes #>)' == ''">
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest_main.dll" Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" />
@@ -76,7 +76,7 @@
       <ReferenceCopyLocalPaths Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\x86\Release\gtest_main.pdb" />
     <# } #>
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm64' And '$(Disable-<#= PackageNameDashes #>)' == ''">
+  <ItemGroup Condition="'$(UseDebugLibraries)' == 'true' And '$(Platform)' == 'arm64' And '$(Disable-<#= PackageNameDashes #>)' == ''">
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Debug\gtestd.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Debug\gtest_maind.dll" Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" />
@@ -87,7 +87,7 @@
       <ReferenceCopyLocalPaths Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Debug\gtest_main.pdb" />
     <# } #>
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'arm64' And '$(Disable-<#= PackageNameDashes #>)' == ''">
+  <ItemGroup Condition="'$(UseDebugLibraries)' != 'true' And '$(Platform)' == 'arm64' And '$(Disable-<#= PackageNameDashes #>)' == ''">
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Release\gtest.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Release\gtest_main.dll" Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" />
@@ -95,7 +95,7 @@
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Release\gtest.pdb" />
       <ReferenceCopyLocalPaths Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm64\Release\gtest_main.pdb" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'arm' And '$(Disable-<#= PackageNameDashes #>)' == ''">
+  <ItemGroup Condition="'$(UseDebugLibraries)' == 'true' And '$(Platform)' == 'arm' And '$(Disable-<#= PackageNameDashes #>)' == ''">
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Debug\gtestd.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Debug\gtest_maind.dll" Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" />
@@ -106,7 +106,7 @@
       <ReferenceCopyLocalPaths Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Debug\gtest_main.pdb" />
     <# } #>
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'arm' And '$(Disable-<#= PackageNameDashes #>)' == ''">
+  <ItemGroup Condition="'$(UseDebugLibraries)' != 'true' And '$(Platform)' == 'arm' And '$(Disable-<#= PackageNameDashes #>)' == ''">
     <# if (ConfigurationType == "dyn") { #>
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Release\gtest.dll" />
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\\<#= PathToBinaries #>\arm\Release\gtest_main.dll" Condition="'$(Microsoft-GoogleTest-Disable-gtest_main)' == ''" />


### PR DESCRIPTION
This patch tries to change the conditions to switch the Google Test libraries to link by using the 'Use Debug Libraries' setting of the configuration. This will make it possible to have multiple Debug configurations.