### PR TITLE
Add build+compliance pipeline with conversion to latest 1ES standards

### DIFF
--- a/GoogleTestAdapter/SetVersion.ps1
+++ b/GoogleTestAdapter/SetVersion.ps1
@@ -1,33 +1,33 @@
 Param([parameter(Mandatory=$true)] [string] $version)
 
-$common_assembly_info = "Common\Properties\AssemblyInfo.cs"
+$common_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\Common\Properties\AssemblyInfo.cs"
 
-$common_dynamic_gta_assembly_info = "Common.Dynamic.GTA\Properties\AssemblyInfo.cs"
-$common_dynamic_tafgt_assembly_info = "Common.Dynamic.TAfGT\Properties\AssemblyInfo.cs"
+$common_dynamic_gta_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\Common.Dynamic.GTA\Properties\AssemblyInfo.cs"
+$common_dynamic_tafgt_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\Common.Dynamic.TAfGT\Properties\AssemblyInfo.cs"
 
-$core_assembly_info = "Core\Properties\AssemblyInfo.cs"
-$coretests_assembly_info = "Core.Tests\Properties\AssemblyInfo.cs"
+$core_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\Core\Properties\AssemblyInfo.cs"
+$coretests_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\Core.Tests\Properties\AssemblyInfo.cs"
 
-$dia_assembly_info = "DiaResolver\Properties\AssemblyInfo.cs"
-$diatests_assembly_info = "DiaResolver.Tests\Properties\AssemblyInfo.cs"
+$dia_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\DiaResolver\Properties\AssemblyInfo.cs"
+$diatests_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\DiaResolver.Tests\Properties\AssemblyInfo.cs"
 
-$packaging_gta_assembly_info = "Packaging.GTA\Properties\AssemblyInfo.cs"
-$packaging_tafgt_assembly_info = "Packaging.TAfGT\Properties\AssemblyInfo.cs"
-$projecttemplates_vstemplate = "GoogleTestProjectTemplate\GoogleTest.vstemplate"
+$packaging_gta_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\Packaging.GTA\Properties\AssemblyInfo.cs"
+$packaging_tafgt_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\Packaging.TAfGT\Properties\AssemblyInfo.cs"
+$projecttemplates_vstemplate = "TestAdapterForGoogleTest\GoogleTestAdapter\GoogleTestProjectTemplate\GoogleTest.vstemplate"
 
-$testadapter_assembly_info = "TestAdapter\Properties\AssemblyInfo.cs"
-$testadaptertests_assembly_info = "TestAdapter.Tests\Properties\AssemblyInfo.cs"
+$testadapter_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\TestAdapter\Properties\AssemblyInfo.cs"
+$testadaptertests_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\TestAdapter.Tests\Properties\AssemblyInfo.cs"
 
-$vspackage_gta_assembly_info = "VsPackage.GTA\Properties\AssemblyInfo.cs"
-$vspackage_gta_unittests_assembly_info = "VsPackage.GTA.Tests.Unit\Properties\AssemblyInfo.cs"
-$vspackage_tafgt_assembly_info = "VsPackage.TAfGT\Properties\AssemblyInfo.cs"
-$vspackagetests_assembly_info = "VsPackage.Tests\Properties\AssemblyInfo.cs"
-$vspackagegeneratedtests_assembly_info = "VsPackage.Tests.Generated\Properties\AssemblyInfo.cs"
+$vspackage_gta_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\VsPackage.GTA\Properties\AssemblyInfo.cs"
+$vspackage_gta_unittests_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\VsPackage.GTA.Tests.Unit\Properties\AssemblyInfo.cs"
+$vspackage_tafgt_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\VsPackage.TAfGT\Properties\AssemblyInfo.cs"
+$vspackagetests_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\VsPackage.Tests\Properties\AssemblyInfo.cs"
+$vspackagegeneratedtests_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\VsPackage.Tests.Generated\Properties\AssemblyInfo.cs"
 
-$vsix_manifest_gta = "Packaging.GTA\source.extension.vsixmanifest"
-$vsix_manifest_tafgt = "Packaging.TAfGT\source.extension.vsixmanifest"
+$vsix_manifest_gta = "TestAdapterForGoogleTest\GoogleTestAdapter\Packaging.GTA\source.extension.vsixmanifest"
+$vsix_manifest_tafgt = "TestAdapterForGoogleTest\GoogleTestAdapter\Packaging.TAfGT\source.extension.vsixmanifest"
 
-$wizard_assembly_info = "NewProjectWizard\Properties\AssemblyInfo.cs"
+$wizard_assembly_info = "TestAdapterForGoogleTest\GoogleTestAdapter\NewProjectWizard\Properties\AssemblyInfo.cs"
 
 (Get-Content $common_assembly_info) | ForEach-Object { $_ -replace "0.1.0.0", $version } | Set-Content $common_assembly_info
 

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -248,24 +248,24 @@ function Build-NuGet {
     $TargetsTTArgs += "/p:PathToBinaries=`"$PathToBinaries`""
     $TargetsTTArgs += "/p:ConfigurationType=`"$(Convert-DynamicLibraryLinkageToString $DynamicLibraryLinkage)`""
     $TargetsTTArgs += "/p:OutputFileName=`"$Dir\build\native\$PackageName.targets`""
-    $TargetsTTArgs += "googletest.targets.tt.proj"
+    $TargetsTTArgs += "TestAdapterForGoogleTest\GoogleTestNuGet\googletest.targets.tt.proj"
     Invoke-Executable msbuild $TargetsTTArgs
 
     # Copy all the locale ID folders with the localized versions of googletest.propertiesui.xml
-    Copy-Item -Path "1028" -Destination "$Dir\build\native\1028" -Recurse
-    Copy-Item -Path "1029" -Destination "$Dir\build\native\1029" -Recurse
-    Copy-Item -Path "1031" -Destination "$Dir\build\native\1031" -Recurse
-    Copy-Item -Path "1033" -Destination "$Dir\build\native\1033" -Recurse
-    Copy-Item -Path "1034" -Destination "$Dir\build\native\1034" -Recurse
-    Copy-Item -Path "1036" -Destination "$Dir\build\native\1036" -Recurse
-    Copy-Item -Path "1040" -Destination "$Dir\build\native\1040" -Recurse
-    Copy-Item -Path "1041" -Destination "$Dir\build\native\1041" -Recurse
-    Copy-Item -Path "1042" -Destination "$Dir\build\native\1042" -Recurse
-    Copy-Item -Path "1045" -Destination "$Dir\build\native\1045" -Recurse
-    Copy-Item -Path "1046" -Destination "$Dir\build\native\1046" -Recurse
-    Copy-Item -Path "1049" -Destination "$Dir\build\native\1049" -Recurse
-    Copy-Item -Path "1055" -Destination "$Dir\build\native\1055" -Recurse
-    Copy-Item -Path "2052" -Destination "$Dir\build\native\2052" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1028" -Destination "$Dir\build\native\1028" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1029" -Destination "$Dir\build\native\1029" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1031" -Destination "$Dir\build\native\1031" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1033" -Destination "$Dir\build\native\1033" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1034" -Destination "$Dir\build\native\1034" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1036" -Destination "$Dir\build\native\1036" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1040" -Destination "$Dir\build\native\1040" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1041" -Destination "$Dir\build\native\1041" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1042" -Destination "$Dir\build\native\1042" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1045" -Destination "$Dir\build\native\1045" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1046" -Destination "$Dir\build\native\1046" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1049" -Destination "$Dir\build\native\1049" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\1055" -Destination "$Dir\build\native\1055" -Recurse
+    Copy-Item -Path "TestAdapterForGoogleTest\GoogleTestNuGet\2052" -Destination "$Dir\build\native\2052" -Recurse
 
     Copy-Item -Recurse -Path "googletest\googletest\include" -Destination "$Dir\build\native\include"
 
@@ -305,13 +305,13 @@ function Build-NuGet {
         }
     }
 
-    Copy-CreateItem -Recurse -Path "license (MIT).txt"     -Destination "$Dir\license (MIT).txt"
-    Copy-CreateItem -Recurse -Path "ThirdPartyNotices.txt" -Destination "$Dir\ThirdPartyNotices.txt"
+    Copy-CreateItem -Recurse -Path "TestAdapterForGoogleTest\GoogleTestNuGet\license (MIT).txt"     -Destination "$Dir\license (MIT).txt"
+    Copy-CreateItem -Recurse -Path "TestAdapterForGoogleTest\GoogleTestNuGet\ThirdPartyNotices.txt" -Destination "$Dir\ThirdPartyNotices.txt"
 
     $NuspecTTArgs = @()
     $NuspecTTArgs += "/p:PackageName=`"$PackageName`""
     $NuspecTTArgs += "/p:OutputFileName=`"$Dir\googletest.nuspec`""
-    $NuspecTTArgs += "googletest.nuspec.tt.proj"
+    $NuspecTTArgs += "TestAdapterForGoogleTest\GoogleTestNuGet\googletest.nuspec.tt.proj"
     Invoke-Executable msbuild $NuspecTTArgs
 
     $NugetPackArgs = @()

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -8,7 +8,7 @@ available through PATH, e.g. made through Developer Command Prompt for VS.
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
-    [ValidateScript({Test-Path $_ -PathType 'Container'})]
+        [ValidateScript({Test-Path $_ -PathType 'Container'})]
         [string]$VSPath
 )
 Set-StrictMode -Version Latest

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -367,7 +367,7 @@ function Main {
     }
     Invoke-Executable nuget
 
-    $OutputDir = "..\GoogleTestAdapter\Packages"
+    $OutputDir = "TestAdapterForGoogleTest\GoogleTestAdapter\Packages"
 
     Build-BinariesAndNuGet -ToolsetName "v140" -BuildToolset "v141" -DynamicLibraryLinkage $false -DynamicCRTLinkage $true  -OutputDir $OutputDir
     Build-BinariesAndNuGet -ToolsetName "v140" -BuildToolset "v141" -DynamicLibraryLinkage $false -DynamicCRTLinkage $false -OutputDir $OutputDir

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -8,7 +8,7 @@ available through PATH, e.g. made through Developer Command Prompt for VS.
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
-        [ValidateScript({Test-Path $_ -PathType 'Container'})]
+    [ValidateScript({Test-Path $_ -PathType 'Container'})]
         [string]$VSPath
 )
 Set-StrictMode -Version Latest
@@ -189,7 +189,7 @@ function Build-Binaries {
     $Dir = Create-WorkingDirectory -Prefix "build" -ToolsetName $ToolsetName -BuildToolset $BuildToolset -Platform $Platform `
         -DynamicLibraryLinkage $DynamicLibraryLinkage -DynamicCRTLinkage $DynamicCRTLinkage
 
-    $CMakeDir = "$pwd\..\ThirdParty\googletest\googletest"
+    $CMakeDir = "$pwd\googletest\googletest"
 
     Push-Location $Dir
     try {
@@ -267,7 +267,7 @@ function Build-NuGet {
     Copy-Item -Path "1055" -Destination "$Dir\build\native\1055" -Recurse
     Copy-Item -Path "2052" -Destination "$Dir\build\native\2052" -Recurse
 
-    Copy-Item -Recurse -Path "..\ThirdParty\googletest\googletest\include" -Destination "$Dir\build\native\include"
+    Copy-Item -Recurse -Path "googletest\googletest\include" -Destination "$Dir\build\native\include"
 
     $BuildToDestinationPath = @()
     $BuildToDestinationPath += ,@($BuildDir32, "$Dir\$PathToBinaries\x86")

--- a/TSAOptions.json
+++ b/TSAOptions.json
@@ -1,0 +1,21 @@
+{
+    "tsaVersion": "TsaV2",
+    "codebase": "NewOrUpdate",
+    "codebaseName": "VCLS GoogleTest GitHub",
+    "tsaStamp": "DevDiv",
+    "tsaEnvironment": "PROD",
+    "notificationAliases": [
+       "cppintellisense@microsoft.com",
+       "bogdan.mihalcea@microsoft.com"
+    ],
+    "codebaseAdmins": [
+        "REDMOND\\bogdanm",
+        "REDMOND\\cpp-apogee"
+    ],
+    "instanceUrl": "https://devdiv.visualstudio.com",
+    "projectName": "DevDiv",
+    "areaPath": "DevDiv\\Cpp Developer Experience\\Apogee\\Google Test and Boost Test integration",
+    "iterationPath": "DevDiv",
+    "alltools": true,
+    "repositoryName": "VCLS-Extensions"
+ }

--- a/TSAOptions.json
+++ b/TSAOptions.json
@@ -10,7 +10,7 @@
     ],
     "codebaseAdmins": [
         "REDMOND\\bogdanm",
-        "REDMOND\\cpp-apogee"
+        "REDMOND\\cppintellisense"
     ],
     "instanceUrl": "https://devdiv.visualstudio.com",
     "projectName": "DevDiv",

--- a/TestAdapterForGoogleTest/tsaoptions.json
+++ b/TestAdapterForGoogleTest/tsaoptions.json
@@ -1,0 +1,21 @@
+{
+    "tsaVersion": "TsaV2",
+    "codebase": "NewOrUpdate",
+    "codebaseName": "VCLS GoogleTest GitHub",
+    "tsaStamp": "DevDiv",
+    "tsaEnvironment": "PROD",
+    "notificationAliases": [
+       "cppintellisense@microsoft.com",
+       "bogdan.mihalcea@microsoft.com"
+    ],
+    "codebaseAdmins": [
+        "REDMOND\\bogdanm",
+        "REDMOND\\cpp-apogee"
+    ],
+    "instanceUrl": "https://devdiv.visualstudio.com",
+    "projectName": "DevDiv",
+    "areaPath": "DevDiv\\Cpp Developer Experience\\Apogee\\Google Test and Boost Test integration",
+    "iterationPath": "DevDiv",
+    "alltools": true,
+    "repositoryName": "VCLS-Extensions"
+ }

--- a/TestAdapterForGoogleTest/tsaoptions.json
+++ b/TestAdapterForGoogleTest/tsaoptions.json
@@ -10,7 +10,7 @@
     ],
     "codebaseAdmins": [
         "REDMOND\\bogdanm",
-        "REDMOND\\cpp-apogee"
+        "REDMOND\\cppintellisense"
     ],
     "instanceUrl": "https://devdiv.visualstudio.com",
     "projectName": "DevDiv",

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -78,10 +78,10 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2022GPT-1ES
+      name: VSEngSS-MicroBuild2019-1ES
     sdl:
       sourceAnalysisPool:
-        name: VSEngSS-MicroBuild2022-1ES
+        name: VSEngSS-MicroBuild2019-1ES
       sourceRepositoriesToScan:
         exclude:
         - repository: MicroBuildTemplate

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -325,23 +325,6 @@ extends:
             continueOnError: true
           env:
             AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
-        - task: PowerShell@2
-          displayName: Pull msdia symbols
-          inputs:
-            targetType: inline
-            script: |-
-              # Using symchk to pull the symbols as BinSkim cannot cope with the symbol server currently.
-              # NOTE: availability of symchk depends on APIScan being pulled down first, so this step must follow APIScan and may require updates to path as APIScan is revised.
-              $symchkPath = (Get-ChildItem -Path "C:/ToolCache/Guardian/_gdn/" -Recurse -Filter "symchk.exe").FullName
-              if (Test-Path C:\Symbols) { Remove-Item C:\Symbols -Recurse -Force }
-              Write-Host "*** x86 ***"
-              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\Core\x86\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
-              Write-Host "*** x64 ***"
-              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\Core\x64\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
-              Write-Host "*** arm ***"
-              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\Core\arm\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
-              Write-Host "*** arm64 ***"
-              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\Core\arm64\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
         - task: 1ES.MicroBuildVstsDrop@1
           displayName: Upload VSTS Drop
           inputs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -334,13 +334,13 @@ extends:
               $symchkPath = (Get-ChildItem -Path "C:/ToolCache/Guardian/_gdn/" -Recurse -Filter "symchk.exe").FullName
               if (Test-Path C:\Symbols) { Remove-Item C:\Symbols -Recurse -Force }
               Write-Host "*** x86 ***"
-              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\out\binaries\GoogleTestAdapter\Release\Core\x86\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
+              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\Core\x86\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
               Write-Host "*** x64 ***"
-              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\out\binaries\GoogleTestAdapter\Release\Core\x64\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
+              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\Core\x64\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
               Write-Host "*** arm ***"
-              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\out\binaries\GoogleTestAdapter\Release\Core\arm\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
+              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\Core\arm\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
               Write-Host "*** arm64 ***"
-              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\out\binaries\GoogleTestAdapter\Release\Core\arm64\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
+              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\Core\arm64\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
         - task: 1ES.MicroBuildVstsDrop@1
           displayName: Upload VSTS Drop
           inputs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -312,12 +312,14 @@ extends:
             Contents: Packaging.TAfGT.vsix
             TargetFolder: $(Build.ArtifactStagingDirectory)\drop
           continueOnError: true
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: PoliCheck@2
           displayName: 'PoliCheck'
           condition: eq (variables.QuickBuild, False)
           inputs:
             targetType: 'F'
             targetArgument: '$(Build.SourcesDirectory)'
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
           displayName: 'Run APIScan'
           condition: eq (variables.QuickBuild, False)
@@ -331,12 +333,27 @@ extends:
             continueOnError: true
           env:
             AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
           displayName: 'Publish Guardian Artifacts'
           condition: eq (variables.QuickBuild, False)
           inputs:
             PublishProcessedResults: true
           continueOnError: true
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+          displayName: 'TSA Upload'
+          condition: eq (variables.QuickBuild, False)
+          inputs:
+            tsaVersion: TsaV2
+            codebase: NewOrUpdate
+            codeBaseName: 'VCLS GoogleTest GitHub'
+            notificationAlias: 'bogdan.mihalcea@microsoft.com,cppintellisense@microsoft.com'
+            codeBaseAdmins: 'redmond\bogdanm;redmond\cpp-apogee'
+            instanceUrlForTsaV2: DEVDIV
+            projectNameDEVDIV: DevDiv
+            areaPath: 'DevDiv\Cpp Developer Experience\Apogee\Google Test and Boost Test integration'
+            iterationPath: DevDiv
         - task: 1ES.MicroBuildVstsDrop@1
           displayName: Upload VSTS Drop
           inputs:
@@ -368,18 +385,6 @@ extends:
             runInParallel: false
             diagnosticsEnabled: True
           continueOnError: true
-        - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
-          displayName: 'TSA Upload'
-          inputs:
-            tsaVersion: TsaV2
-            codebase: NewOrUpdate
-            codeBaseName: 'VCLS GoogleTest GitHub'
-            notificationAlias: 'bogdan.mihalcea@microsoft.com,cppintellisense@microsoft.com'
-            codeBaseAdmins: 'redmond\bogdanm;redmond\cpp-apogee'
-            instanceUrlForTsaV2: DEVDIV
-            projectNameDEVDIV: DevDiv
-            areaPath: 'DevDiv\Cpp Developer Experience\Apogee\Google Test and Boost Test integration'
-            iterationPath: DevDiv
         - task: 1ES.PublishPipelineArtifact@1
           displayName: 'Publish Artifact: drop'
           inputs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -281,14 +281,12 @@ extends:
             nugetConfigPath: TestAdapterForGoogleTest/NuGet.config
             packagesDirectory: ..\NugetPackages
         - task: VSBuild@1
-          displayName: Build core vsmanproj
+          displayName: 'Build core vsmanproj'
           inputs:
             solution: TestAdapterForGoogleTest/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
-            msbuildArgs: /p:ArtifactsDir=$(Build.ArtifactStagingDirectory)
-            platform: $(BuildPlatform)
-            configuration: $(BuildConfiguration)
+            platform: '$(BuildPlatform)'
+            configuration: '$(BuildConfiguration)'
             maximumCpuCount: true
-          continueOnError: true
         - task: PublishSymbols@1
           displayName: 'Publish symbols path: '
           inputs:
@@ -297,14 +295,14 @@ extends:
         - task: CopyFiles@2
           displayName: Copy setup files to drop root
           inputs:
-            SourceFolder: out\binaries\GoogleTestAdapter\$(BuildConfiguration)\Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest
+            SourceFolder: TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\$(BuildConfiguration)\Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest
             Contents: '*'
             TargetFolder: $(Build.ArtifactStagingDirectory)\drop
           continueOnError: true
         - task: CopyFiles@2
           displayName: Copy vsix to root
           inputs:
-            SourceFolder: out\binaries\GoogleTestAdapter\$(BuildConfiguration)\Packaging.TAfGT
+            SourceFolder: TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\$(BuildConfiguration)\Packaging.TAfGT
             Contents: Packaging.TAfGT.vsix
             TargetFolder: $(Build.ArtifactStagingDirectory)\drop
           continueOnError: true

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -1,0 +1,397 @@
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
+# The SBOM tasks have been removed because they are not required for the unofficial template.
+# You can manually enable SBOM in the unofficial template if needed, othewise its automatically enabled when using official template. https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sbom
+# This pipeline will be extended to the OneESPT template
+# If you are not using the E+D shared hosted pool with windows-2022, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
+# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish Artifact: drop to pipelines' in the templateContext section.
+trigger:
+  branches:
+    include:
+    - refs/heads/dev17
+  batch: True
+name: $(date:yyyyMMdd)$(rev:.r)
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+variables:
+- name: ApiScanClientId
+  value: 1d6a3de7-4a6a-4b75-b15d-e305293c75af
+- name: ApiScanSecret
+  value: "$(TAfGTAPIScanSecret)"
+- name: ApiScanTenant
+  value: 72f988bf-86f1-41af-91ab-2d7cd011db47
+- name: ArtifactServices.Symbol.AccountName
+  value: microsoft
+- name: ArtifactServices.Symbol.PAT
+  value: "$(GoogleTestSymbolsPat)"
+- name: ArtifactServices.Symbol.UseAAD
+  value: False
+- name: BuildConfiguration
+  value: "$(TAfGTBuildConfiguration)"
+- name: BuildPlatform
+  value: Any CPU
+- name: CodeQL.Cadence
+  value: 0
+- name: CodeQL.Enabled
+  value: true
+- name: Codeql.Language
+  value: csharp
+- name: CodeQL.TSAEnabled
+  value: true
+- name: DiaNugetVersion
+  value: "$(TAfGTDiaNugetVersion)"
+- name: DropRoot
+  value: '\\cpvsbuild\drops'
+- name: NUGET_RESTORE_MSBUILD_ARGS
+  value: /p:Configuration="$(BuildConfiguration)"
+- name: Packaging.EnableSBOMSigning
+  value: "$(TAfGTEnableSBOMSigning)"
+- name: DropPAT
+  value: "$(TAfGTDropPAT)"
+- name: ProductComponent
+  value: "$(TAfGTProductComponent)"
+- name: Publish
+  value: "$(TAfGTPublish)"
+- name: RealSign
+  value: "$(TAfGTRealSign)"
+- name: RetainBuild
+  value: "$(TAfGTRetainBuild)"
+- name: SignType
+  value: "$(TAfGTSignType)"
+- name: SYMBOLS_PAT
+  value: "$(GoogleTestSymbolsPat)"
+- name: smPassword
+  value: "$(TAfGTADOUserPassword)"
+- name: smUsername
+  value: davidraygoza
+- name: TeamName
+  value: VCLS
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    pool:
+      name: VSEngSS-MicroBuild2022GPT-1ES
+    sdl:
+      sourceAnalysisPool:
+        name: VSEngSS-MicroBuild2022-1ES
+      sourceRepositoriesToScan:
+        exclude:
+        - repository: MicroBuildTemplate
+        - repository: TestAdapterForGoogleTest
+    stages:
+    - stage: stage
+      jobs:
+      - job: Phase_1
+        displayName: Phase 1
+        timeoutInMinutes: 0
+        cancelTimeoutInMinutes: 1
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: drop to pipelines'
+            targetPath: $(Build.ArtifactStagingDirectory)\drop
+        steps:
+        - checkout: self
+          displayName: 'Checkout TestAdapterForGoogleTest Git Repo'
+          clean: true
+          fetchDepth: 1
+          persistCredentials: true
+        - powershell: |
+            git clone "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/googletest" "$($env:sourceDirectory)\ThirdParty\googletest"
+          displayName: 'Git Repository Clone: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/googletest'
+          env:
+            system_accesstoken: $(System.AccessToken)
+            sourceDirectory: $(Build.SourcesDirectory)
+        - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
+          displayName: Install Localization Plugin
+        - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+          displayName: Install Signing Plugin
+          inputs:
+            signType: $(SignType)
+        - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@4
+          displayName: Install Swix Plugin
+        - task: NuGetToolInstaller@1
+          displayName: Install NuGet
+          inputs:
+            versionSpec: 5.9.1
+        - task: VSBuild@1
+          displayName: Build ResolveTTs.proj
+          inputs:
+            solution: ResolveTTs.proj
+            platform: $(BuildPlatform)
+            configuration: $(BuildConfiguration)
+            maximumCpuCount: true
+        - task: PowerShell@2
+          displayName: Generate TAfGT specific sln
+          inputs:
+            targetType: filePath
+            filePath: './Tools/RemoveGtaProjects.ps1'
+        - task: NuGetCommand@2
+          displayName: NuGet restore to sign packages
+          inputs:
+            solution: GoogleTestNuget/packages.config
+            selectOrConfig: config
+            nugetConfigPath: NuGet.config
+            packagesDirectory: packages
+        - task: NuGetCommand@2
+          displayName: NuGet restore for GoogleTestAdapter.sln
+          inputs:
+            solution: GoogleTestAdapter/GoogleTestAdapter.sln
+            selectOrConfig: config
+            nugetConfigPath: NuGet.config
+        - task: PowerShell@2
+          displayName: Set Version
+          inputs:
+            targetType: filePath
+            workingDirectory: GoogleTestAdapter
+            filePath: './SetVersion.ps1'
+            arguments: '-version 1.17.0.30'
+        - task: PowerShell@1
+          displayName: Add Keys for RealSign to TAfGT
+          inputs:
+            scriptType: inlineScript
+            inlineScript: |-
+              $projects_to_sign = @(
+                "GoogleTestAdapter\Common\Common.csproj",
+                "GoogleTestAdapter\Common.Dynamic.TAfGT\Common.Dynamic.TAfGT.csproj",
+                "GoogleTestAdapter\Core\Core.csproj",
+                "GoogleTestAdapter\DiaResolver\DiaResolver.csproj",
+                "GoogleTestAdapter\NewProjectWizard\NewProjectWizard.csproj",
+                "GoogleTestAdapter\TestAdapter\TestAdapter.csproj",
+                "GoogleTestAdapter\VsPackage.TAfGT\VsPackage.TAfGT.csproj",
+                "GoogleTestAdapter\Packaging.TAfGT\Packaging.TAfGT.csproj"
+              )
+              $projects_to_sign | ForEach-Object {
+                $xml = [xml](Get-Content $_)
+                $KeyFile = $xml.CreateElement("AssemblyOriginatorKeyFile", "http://schemas.microsoft.com/developer/msbuild/2003")
+                $KeyFile.set_InnerXML("`$(EnlistmentRoot)FinalPublicKey.snk")
+                $xml | ForEach-Object { $_.Project.PropertyGroup | ForEach-Object { if ($_.Condition -like '*(RealSign)'' == ''True''') { $_.AppendChild($KeyFile) } } }
+                $xml.Save("$pwd\$_")
+              }
+        - task: PowerShell@1
+          displayName: Add Keys for RealSign to googletest
+          inputs:
+            type: inlineScript
+            inlineScript: |-
+              $build_script = 'GoogleTestNuGet\Build.ps1'
+              $match_string = '*$DelaySign.set_InnerXML("true")*'
+              (Get-Content $build_script) | ForEach-Object {
+                if ($_ -like $match_string) {
+                  $_ + '
+                  $KeyFile = $xml.CreateElement("AssemblyOriginatorKeyFile", "http://schemas.microsoft.com/developer/msbuild/2003")
+                  $KeyFile.set_InnerXML("`$(EnlistmentRoot)FinalPublicKey.snk")
+                  $RealSignGroup.AppendChild($KeyFile) | Out-Null'
+                } else {
+                  $_
+                }
+              } | Set-Content $build_script
+        - task: PowerShell@1
+          displayName: Update token for template
+          inputs:
+            type: inlineScript
+            inlineScript: |-
+              $project_template = 'GoogleTestAdapter\GoogleTestProjectTemplate\GoogleTest.vstemplate'
+              (Get-Content $project_template) | ForEach-Object {
+                $_ -Replace "1924acebdd4c8a75", "b03f5f7f11d50a3a"
+              } | Set-Content $project_template
+        - task: PowerShell@1
+          displayName: Copy internal key
+          inputs:
+            scriptType: inlineScript
+            inlineScript: Invoke-WebRequest -Headers @{"AUTHORIZATION"="bearer $env:SYSTEM_ACCESSTOKEN"}-OutFile 'FinalPublicKey.snk' 'https://devdiv.visualstudio.com/DefaultCollection/0bdbc590-a062-4c3f-b0f6-9383f67865ee/0c9127d6-f650-4a04-9399-25be18b8e2fb/_api/_versioncontrol/itemContent?repositoryId=2961dea4-f77c-4c8e-b46f-72b6bfe62c29&path=%2FInternalAPIs%2FDevDiv%2FFinalPublicKey.snk&version=GBdev15'
+        - task: PowerShell@1
+          displayName: Build GoogleTest NuGet packages
+          inputs:
+            scriptName: GoogleTestNuGet\Build.ps1
+            arguments: -Verbose -VSPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\"
+            workingFolder: GoogleTestNuGet
+            failOnStandardError: false
+        - task: MSBuild@1
+          displayName: Sign NuGet packages
+          inputs:
+            solution: GoogleTestNuGet\googletest.SignNuGet.proj
+        - task: BatchScript@1
+          displayName: Set up developer command prompt environment
+          inputs:
+            filename: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
+            modifyEnvironment: true
+        - task: NuGetCommand@2
+          displayName: NuGet install dia amd64
+          inputs:
+            command: custom
+            arguments: install VS.Redist.Vctools.Amd64 -Version $(DiaNugetVersion) -OutputDirectory vctools -ExcludeVersion -Source https://pkgs.dev.azure.com/devdiv/_packaging/VS-CoreXtFeeds/nuget/v3/index.json -NoCache -DirectDownload -Verbosity Detailed -NonInteractive
+        - task: NuGetCommand@2
+          displayName: NuGet install dia arm
+          inputs:
+            command: custom
+            arguments: install VS.Redist.Vctools.Arm -Version $(DiaNugetVersion) -OutputDirectory vctools -ExcludeVersion -Source https://pkgs.dev.azure.com/devdiv/_packaging/VS-CoreXtFeeds/nuget/v3/index.json -NoCache -DirectDownload -Verbosity Detailed -NonInteractive
+        - task: NuGetCommand@2
+          displayName: NuGet install dia arm64
+          inputs:
+            command: custom
+            arguments: install VS.Redist.Vctools.Arm64 -Version $(DiaNugetVersion) -OutputDirectory vctools -ExcludeVersion -Source https://pkgs.dev.azure.com/devdiv/_packaging/VS-CoreXtFeeds/nuget/v3/index.json -NoCache -DirectDownload -Verbosity Detailed -NonInteractive
+        - task: NuGetCommand@2
+          displayName: NuGet install dia x86
+          inputs:
+            command: custom
+            arguments: install VS.Redist.Vctools.X86Files -Version $(DiaNugetVersion) -OutputDirectory vctools -ExcludeVersion -Source https://pkgs.dev.azure.com/devdiv/_packaging/VS-CoreXtFeeds/nuget/v3/index.json -NoCache -DirectDownload -Verbosity Detailed -NonInteractive
+        - task: PowerShell@2
+          displayName: Build and copy dia binaries
+          inputs:
+            targetType: inline
+            script: |-
+              .\compile_typelib.ps1
+              Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.Amd64\msdia140.dll' -Destination '..\x64\msdia140.dll' -verbose
+              Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.Arm\msdia140.dll' -Destination '..\arm\msdia140.dll' -verbose
+              Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.Arm64\msdia140.dll' -Destination '..\arm64\msdia140.dll' -verbose
+              Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.X86Files\msdia140.dll' -Destination '..\x86\msdia140.dll' -verbose
+            workingDirectory: GoogleTestAdapter/DiaResolver/dia2
+        - task: VSBuild@1
+          displayName: Build GoogleTestAdapter.sln
+          inputs:
+            solution: GoogleTestAdapter/GoogleTestAdapter.sln
+            platform: $(BuildPlatform)
+            configuration: $(BuildConfiguration)
+            maximumCpuCount: true
+            createLogFile: true
+        - task: CopyFiles@2
+          displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\drop'
+          inputs:
+            Contents: '**\out\binaries\**'
+            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: 'Manifest Generator '
+          inputs:
+            BuildDropPath: '$(Build.ArtifactStagingDirectory)\drop'
+        - task: NuGetCommand@2
+          displayName: NuGet restore vsmanproj
+          inputs:
+            solution: swix/packages.config
+            selectOrConfig: config
+            nugetConfigPath: NuGet.config
+            packagesDirectory: ..\NugetPackages
+        - task: VSBuild@1
+          displayName: Build core vsmanproj
+          inputs:
+            solution: swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
+            msbuildArgs: /p:ArtifactsDir=$(Build.ArtifactStagingDirectory)
+            platform: $(BuildPlatform)
+            configuration: $(BuildConfiguration)
+            maximumCpuCount: true
+          continueOnError: true
+        - task: PublishSymbols@1
+          displayName: 'Publish symbols path: '
+          inputs:
+            SearchPattern: out\binaries\**\*.pdb
+          continueOnError: true
+        - task: CopyFiles@2
+          displayName: Copy setup files to drop root
+          inputs:
+            SourceFolder: out\binaries\GoogleTestAdapter\$(BuildConfiguration)\Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest
+            Contents: '*'
+            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
+          continueOnError: true
+        - task: CopyFiles@2
+          displayName: Copy vsix to root
+          inputs:
+            SourceFolder: out\binaries\GoogleTestAdapter\$(BuildConfiguration)\Packaging.TAfGT
+            Contents: Packaging.TAfGT.vsix
+            TargetFolder: $(Build.ArtifactStagingDirectory)\drop
+          continueOnError: true
+        - task: whitesource.ws-bolt.bolt.wss.WhiteSource Bolt@1
+          displayName: 'WhiteSource Bolt'
+          continueOnError: true
+        - task: CmdLine@2
+          displayName: Set APIScan environment
+          inputs:
+            script: setx AzureServicesAuthConnectionString runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret) /m
+        - task: PoliCheck@2
+          inputs:
+            targetType: 'F'
+            targetArgument: '$(Build.SourcesDirectory)'
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
+          displayName: 'Run APIScan'
+          inputs:
+            softwareFolder: '$(Build.ArtifactStagingDirectory)\drop'
+            softwareName: GoogleTest
+            softwareVersionNum: 1.0
+            isLargeApp: false
+            toolVersion: 'Latest'
+            verbosityLevel: silent
+            continueOnError: true
+        - task: CmdLine@2
+          displayName: Clear APIScan environment
+          inputs:
+            script: setx AzureServicesAuthConnectionString "" /m
+        - task: PowerShell@2
+          displayName: Pull msdia symbols
+          inputs:
+            targetType: inline
+            script: |-
+              # Using symchk to pull the symbols as BinSkim cannot cope with the symbol server currently.
+              # NOTE: availability of symchk depends on APIScan being pulled down first, so this step must follow APIScan and may require updates to path as APIScan is revised.
+              $symchkPath = "D:\a\_work\_gdn\packages\nuget\VisualCppTools.MicrosoftInternal.APIScan.x64.3.3.23505.0\tools\symchk.exe" 
+              if (Test-Path C:\Symbols) { Remove-Item C:\Symbols -Recurse -Force }
+              Write-Host "*** x86 ***"
+              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\out\binaries\GoogleTestAdapter\Release\Core\x86\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
+              Write-Host "*** x64 ***"
+              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\out\binaries\GoogleTestAdapter\Release\Core\x64\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
+              Write-Host "*** arm ***"
+              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\out\binaries\GoogleTestAdapter\Release\Core\arm\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
+              Write-Host "*** arm64 ***"
+              & $symchkPath $(Build.ArtifactStagingDirectory)\drop\out\binaries\GoogleTestAdapter\Release\Core\arm64\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
+        - task: 1ES.MicroBuildVstsDrop@1
+          displayName: Upload VSTS Drop
+          inputs:
+            dropFolder: $(Build.ArtifactStagingDirectory)\drop
+            dropName: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+            accessToken: $(DropPAT)
+            dropServiceUri: https://devdiv.artifacts.visualstudio.com/DefaultCollection
+            vsDropServiceUri: "https://vsdrop.corp.microsoft.com/file/v1"
+        - task: ms-vseng.MicroBuildShipTasks.4a4e1dc3-01d0-484f-94ac-f918aaf7d509.MicroBuildRetainVstsDrops@1
+          displayName: Retain VSTS Drops
+          condition: and(succeeded(), eq(variables['RetainBuild'], true))
+          inputs:
+            DropNames: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+            AccessToken: $(DropPAT)
+            DropServiceUri: https://devdiv.artifacts.visualstudio.com/DefaultCollection
+        - task: PublishSymbols@2
+          displayName: Publish symbols path
+          inputs:
+            SymbolsFolder: $(Build.ArtifactStagingDirectory)\drop
+            SearchPattern: '**/*.pdb'
+            SymbolServerType: TeamServices
+        - task: VSTest@2
+          displayName: Run Tests
+          inputs:
+            testAssemblyVer2: |-
+              out\binaries\GoogleTestAdapter\Release\**\*.Tests.*dll
+              **\*.Tests.Common.*dll
+            vsTestVersion: 15.0
+            runInParallel: false
+            diagnosticsEnabled: True
+          continueOnError: true
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
+          displayName: 'Publish Guardian Artifacts'
+          inputs:
+            PublishProcessedResults: true
+          continueOnError: true
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+          displayName: 'TSA Upload'
+          inputs:
+            tsaVersion: TsaV2
+            codebase: NewOrUpdate
+            codeBaseName: 'VCLS GoogleTest GitHub'
+            notificationAlias: 'lukaszme@microsoft.com,cpp-apogee@microsoft.com'
+            codeBaseAdmins: 'redmond\lukaszme;redmond\cpp-apogee'
+            instanceUrlForTsaV2: DEVDIV
+            projectNameDEVDIV: DevDiv
+            areaPath: 'DevDiv\Cpp Developer Experience\Apogee\Google Test and Boost Test integration'
+    iterationPath: DevDiv
+        - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+          displayName: Perform Cleanup Tasks
+          condition: always()

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -255,7 +255,7 @@ extends:
               Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.Arm\msdia140.dll' -Destination '..\arm\msdia140.dll' -verbose
               Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.Arm64\msdia140.dll' -Destination '..\arm64\msdia140.dll' -verbose
               Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.X86Files\msdia140.dll' -Destination '..\x86\msdia140.dll' -verbose
-            workingDirectory: GoogleTestAdapter/DiaResolver/dia2
+            workingDirectory: TestAdapterForGoogleTest/GoogleTestAdapter/DiaResolver/dia2
         - task: VSBuild@1
           displayName: Build GoogleTestAdapter.sln
           inputs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -374,8 +374,8 @@ extends:
             tsaVersion: TsaV2
             codebase: NewOrUpdate
             codeBaseName: 'VCLS GoogleTest GitHub'
-            notificationAlias: 'lukaszme@microsoft.com,cpp-apogee@microsoft.com'
-            codeBaseAdmins: 'redmond\lukaszme;redmond\cpp-apogee'
+            notificationAlias: 'bogdan.mihalcea@microsoft.com,cppintellisense@microsoft.com'
+            codeBaseAdmins: 'redmond\bogdanm;redmond\cpp-apogee'
             instanceUrlForTsaV2: DEVDIV
             projectNameDEVDIV: DevDiv
             areaPath: 'DevDiv\Cpp Developer Experience\Apogee\Google Test and Boost Test integration'

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -112,6 +112,11 @@ extends:
           clean: true
           fetchDepth: 1
           persistCredentials: true
+        - checkout: googletest
+          displayName: 'Checkout googletest ADO Repo'
+          clean: true
+          fetchDepth: 1
+          persistCredentials: true
         - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
           displayName: Install Localization Plugin
         - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
@@ -176,11 +181,6 @@ extends:
                 $xml | ForEach-Object { $_.Project.PropertyGroup | ForEach-Object { if ($_.Condition -like '*(RealSign)'' == ''True''') { $_.AppendChild($KeyFile) } } }
                 $xml.Save("$pwd\$_")
               }
-        - checkout: googletest
-          displayName: 'Checkout googletest ADO Repo'
-          clean: true
-          fetchDepth: 1
-          persistCredentials: true
         - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
           displayName: Add Keys for RealSign to googletest
           inputs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -124,11 +124,11 @@ extends:
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
             maximumCpuCount: true
-        - task: PowerShell@2
+        - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
           displayName: Generate TAfGT specific sln
           inputs:
-            targetType: filePath
-            filePath: './TestAdapterForGoogleTest/Tools/RemoveGtaProjects.ps1'
+            type: FilePath
+            scriptName: TestAdapterForGoogleTest\Tools\RemoveGtaProjects.ps1
         - task: NuGetCommand@2
           displayName: NuGet restore to sign packages
           inputs:
@@ -142,17 +142,16 @@ extends:
             solution: TestAdapterForGoogleTest/GoogleTestAdapter/GoogleTestAdapter.sln
             selectOrConfig: config
             nugetConfigPath: TestAdapterForGoogleTest/NuGet.config
-        - task: PowerShell@2
+        - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
           displayName: Set Version
           inputs:
-            targetType: filePath
-            filePath: './TestAdapterForGoogleTest/GoogleTestAdapter/SetVersion.ps1'
-            arguments: '-version 1.17.0.30'
-        - task: PowerShell@1
+            type: InlineScript
+            script: .\TestAdapterForGoogleTest\GoogleTestAdapter\SetVersion.ps1 -version 1.17.0.30
+        - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
           displayName: Add Keys for RealSign to TAfGT
           inputs:
-            scriptType: inlineScript
-            inlineScript: |-
+            type: InlineScript
+            script: |-
               $projects_to_sign = @(
                 "TestAdapterForGoogleTest\GoogleTestAdapter\Common\Common.csproj",
                 "TestAdapterForGoogleTest\GoogleTestAdapter\Common.Dynamic.TAfGT\Common.Dynamic.TAfGT.csproj",
@@ -175,11 +174,11 @@ extends:
           clean: true
           fetchDepth: 1
           persistCredentials: true
-        - task: PowerShell@1
+        - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
           displayName: Add Keys for RealSign to googletest
           inputs:
-            scriptType: inlineScript
-            inlineScript: |-
+            type: InlineScript
+            script: |-
               $build_script = 'TestAdapterForGoogleTest\GoogleTestNuGet\Build.ps1'
               $match_string = '*$DelaySign.set_InnerXML("true")*'
               (Get-Content $build_script) | ForEach-Object {
@@ -192,11 +191,11 @@ extends:
                   $_
                 }
               } | Set-Content $build_script
-        - task: PowerShell@1
+        - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
           displayName: Update token for template
           inputs:
-            scriptType: inlineScript
-            inlineScript: |-
+            type: InlineScript
+            script: |-
               $project_template = 'TestAdapterForGoogleTest\GoogleTestAdapter\GoogleTestProjectTemplate\GoogleTest.vstemplate'
               (Get-Content $project_template) | ForEach-Object {
                 $_ -Replace "1924acebdd4c8a75", "b03f5f7f11d50a3a"

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -75,6 +75,8 @@ variables:
   value: davidraygoza
 - name: TeamName
   value: VCLS
+- name: VersionNumber
+  value: "$(TAfGTVersionNumber)"
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
@@ -162,11 +164,12 @@ extends:
             solution: TestAdapterForGoogleTest/GoogleTestAdapter/GoogleTestAdapter.sln
             selectOrConfig: config
             nugetConfigPath: TestAdapterForGoogleTest/NuGet.config
-        - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
+        - task: PowerShell@2
           displayName: Set Version
           inputs:
-            type: InlineScript
-            script: .\TestAdapterForGoogleTest\GoogleTestAdapter\SetVersion.ps1 -version 1.17.0.30
+            targetType: filePath
+            filePath: './TestAdapterForGoogleTest/GoogleTestAdapter/SetVersion.ps1'
+            arguments: '-version $(VersionNumber)'
         - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
           displayName: Add Keys for RealSign to TAfGT
           inputs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -95,7 +95,7 @@ extends:
         - repository: googletest
       tsa:
         enabled: true
-        configFile: '$(Build.SourcesDirectory)\TestAdapterForGoogleTest\TSAOptions.json'
+        configFile: '$(Build.SourcesDirectory)\TestAdapterForGoogleTest\tsaoptions.json'
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -58,6 +58,9 @@ variables:
   value: "$(TAfGTProductComponent)"
 - name: Publish
   value: "$(TAfGTPublish)"
+  # Quick build is used to skip some compliance tasks to quickly generate a .vsix for testing.
+- name: QuickBuild
+  value: "$(TAfGTQuickBuild)"
 - name: RealSign
   value: "$(TAfGTRealSign)"
 - name: RetainBuild
@@ -310,11 +313,14 @@ extends:
             TargetFolder: $(Build.ArtifactStagingDirectory)\drop
           continueOnError: true
         - task: PoliCheck@2
+          displayName: 'PoliCheck'
+          condition: eq (variables.QuickBuild, False)
           inputs:
             targetType: 'F'
             targetArgument: '$(Build.SourcesDirectory)'
         - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
           displayName: 'Run APIScan'
+          condition: eq (variables.QuickBuild, False)
           inputs:
             softwareFolder: '$(Build.ArtifactStagingDirectory)\drop'
             softwareName: GoogleTest
@@ -325,6 +331,12 @@ extends:
             continueOnError: true
           env:
             AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
+          displayName: 'Publish Guardian Artifacts'
+          condition: eq (variables.QuickBuild, False)
+          inputs:
+            PublishProcessedResults: true
+          continueOnError: true
         - task: 1ES.MicroBuildVstsDrop@1
           displayName: Upload VSTS Drop
           inputs:
@@ -355,11 +367,6 @@ extends:
             vsTestVersion: 15.0
             runInParallel: false
             diagnosticsEnabled: True
-          continueOnError: true
-        - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
-          displayName: 'Publish Guardian Artifacts'
-          inputs:
-            PublishProcessedResults: true
           continueOnError: true
         - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
           displayName: 'TSA Upload'

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -91,9 +91,10 @@ extends:
       sourceAnalysisPool:
         name: VSEngSS-MicroBuild2019-1ES
       sourceRepositoriesToScan:
-        exclude:
-        - repository: MicroBuildTemplate
+        include:
         - repository: googletest
+      customBuildTags:
+        - ES365AIMigrationTooling
     stages:
     - stage: stage
       jobs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -209,7 +209,7 @@ extends:
           displayName: Build GoogleTest NuGet packages
           inputs:
             scriptName: TestAdapterForGoogleTest\GoogleTestNuGet\Build.ps1
-            arguments: -Verbose -VSPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\"
+            arguments: -Verbose -VSPath "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\"
             failOnStandardError: false
         - task: MSBuild@1
           displayName: Sign NuGet packages
@@ -218,7 +218,7 @@ extends:
         - task: BatchScript@1
           displayName: Set up developer command prompt environment
           inputs:
-            filename: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
+            filename: C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat
             modifyEnvironment: true
         - task: NuGetCommand@2
           displayName: NuGet install dia amd64

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -276,7 +276,7 @@ extends:
         - task: NuGetCommand@2
           displayName: NuGet restore vsmanproj
           inputs:
-            solution: swix/packages.config
+            solution: TestAdapterForGoogleTest/swix/packages.config
             selectOrConfig: config
             nugetConfigPath: TestAdapterForGoogleTest/NuGet.config
             packagesDirectory: ..\NugetPackages

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -79,6 +79,13 @@ extends:
   parameters:
     pool:
       name: VSEngSS-MicroBuild2019-1ES
+      demands:
+      - vstest
+      - msbuild
+      - visualstudio
+      - DotNetFramework
+      - Cmd
+      - npm
     sdl:
       sourceAnalysisPool:
         name: VSEngSS-MicroBuild2019-1ES

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -91,10 +91,16 @@ extends:
       sourceAnalysisPool:
         name: VSEngSS-MicroBuild2019-1ES
       sourceRepositoriesToScan:
-        include:
+        exclude:
         - repository: googletest
-      customBuildTags:
-        - ES365AIMigrationTooling
+      tsa:
+        enabled: true
+        configFile: '$(Build.SourcesDirectory)\TestAdapterForGoogleTest\TSAOptions.json'
+      binskim:
+        enabled: true
+        scanOutputDirectoryOnly: true
+    customBuildTags:
+    - ES365AIMigrationTooling
     stages:
     - stage: stage
       jobs:
@@ -287,7 +293,7 @@ extends:
             packagesDirectory: ..\NugetPackages
         - task: VSBuild@1
           displayName: 'Build core vsmanproj'
-          continueOnError: True
+          continueOnError: true
           inputs:
             solution: TestAdapterForGoogleTest/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
             msbuildArgs: /p:ArtifactsDir=$(Build.ArtifactStagingDirectory)
@@ -341,20 +347,16 @@ extends:
           inputs:
             PublishProcessedResults: true
           continueOnError: true
-        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
-        - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
-          displayName: 'TSA Upload'
-          condition: eq (variables.QuickBuild, False)
+        - task: VSTest@2
+          displayName: Run Tests
           inputs:
-            tsaVersion: TsaV2
-            codebase: NewOrUpdate
-            codeBaseName: 'VCLS GoogleTest GitHub'
-            notificationAlias: 'bogdan.mihalcea@microsoft.com,cppintellisense@microsoft.com'
-            codeBaseAdmins: 'redmond\bogdanm;redmond\cpp-apogee'
-            instanceUrlForTsaV2: DEVDIV
-            projectNameDEVDIV: DevDiv
-            areaPath: 'DevDiv\Cpp Developer Experience\Apogee\Google Test and Boost Test integration'
-            iterationPath: DevDiv
+            testAssemblyVer2: |-
+              TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\**\*.Tests.*dll
+              **\*.Tests.Common.*dll
+            vsTestVersion: 15.0
+            runInParallel: false
+            diagnosticsEnabled: True
+          continueOnError: true
         - task: 1ES.MicroBuildVstsDrop@1
           displayName: Upload VSTS Drop
           inputs:
@@ -370,16 +372,6 @@ extends:
             DropNames: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
             AccessToken: $(DropPAT)
             DropServiceUri: https://devdiv.artifacts.visualstudio.com/DefaultCollection
-        - task: VSTest@2
-          displayName: Run Tests
-          inputs:
-            testAssemblyVer2: |-
-              TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\**\*.Tests.*dll
-              **\*.Tests.Common.*dll
-            vsTestVersion: 15.0
-            runInParallel: false
-            diagnosticsEnabled: True
-          continueOnError: true
         - task: 1ES.PublishPipelineArtifact@1
           displayName: 'Publish Artifact: drop'
           inputs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -326,7 +326,7 @@ extends:
             script: |-
               # Using symchk to pull the symbols as BinSkim cannot cope with the symbol server currently.
               # NOTE: availability of symchk depends on APIScan being pulled down first, so this step must follow APIScan and may require updates to path as APIScan is revised.
-              $symchkPath = "D:\a\_work\_gdn\packages\nuget\VisualCppTools.MicrosoftInternal.APIScan.x64.3.3.24044.1\tools\symchk.exe" 
+              $symchkPath = (Get-ChildItem -Path "C:/ToolCache/Guardian/_gdn/" -Recurse -Filter "symchk.exe").FullName
               if (Test-Path C:\Symbols) { Remove-Item C:\Symbols -Recurse -Force }
               Write-Host "*** x86 ***"
               & $symchkPath $(Build.ArtifactStagingDirectory)\drop\out\binaries\GoogleTestAdapter\Release\Core\x86\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -13,6 +13,10 @@ trigger:
 name: $(date:yyyyMMdd)$(rev:.r)
 resources:
   repositories:
+  - repository: googletest
+    type: git
+    name: googletest
+    ref: refs/heads/main
   - repository: MicroBuildTemplate
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
@@ -82,6 +86,7 @@ extends:
         exclude:
         - repository: MicroBuildTemplate
         - repository: TestAdapterForGoogleTest
+        - repository: googletest
     stages:
     - stage: stage
       jobs:
@@ -100,12 +105,6 @@ extends:
           clean: true
           fetchDepth: 1
           persistCredentials: true
-        - powershell: |
-            git clone "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/googletest" "$($env:sourceDirectory)\ThirdParty\googletest"
-          displayName: 'Git Repository Clone: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/googletest'
-          env:
-            system_accesstoken: $(System.AccessToken)
-            sourceDirectory: $(Build.SourcesDirectory)
         - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
           displayName: Install Localization Plugin
         - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
@@ -121,7 +120,7 @@ extends:
         - task: VSBuild@1
           displayName: Build ResolveTTs.proj
           inputs:
-            solution: ResolveTTs.proj
+            solution: TestAdapterForGoogleTest/ResolveTTs.proj
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
             maximumCpuCount: true
@@ -129,26 +128,25 @@ extends:
           displayName: Generate TAfGT specific sln
           inputs:
             targetType: filePath
-            filePath: './Tools/RemoveGtaProjects.ps1'
+            filePath: './TestAdapterForGoogleTest/Tools/RemoveGtaProjects.ps1'
         - task: NuGetCommand@2
           displayName: NuGet restore to sign packages
           inputs:
-            solution: GoogleTestNuget/packages.config
+            solution: TestAdapterForGoogleTest/GoogleTestNuget/packages.config
             selectOrConfig: config
-            nugetConfigPath: NuGet.config
+            nugetConfigPath: TestAdapterForGoogleTest/NuGet.config
             packagesDirectory: packages
         - task: NuGetCommand@2
           displayName: NuGet restore for GoogleTestAdapter.sln
           inputs:
-            solution: GoogleTestAdapter/GoogleTestAdapter.sln
+            solution: TestAdapterForGoogleTest/GoogleTestAdapter/GoogleTestAdapter.sln
             selectOrConfig: config
-            nugetConfigPath: NuGet.config
+            nugetConfigPath: TestAdapterForGoogleTest/NuGet.config
         - task: PowerShell@2
           displayName: Set Version
           inputs:
             targetType: filePath
-            workingDirectory: GoogleTestAdapter
-            filePath: './SetVersion.ps1'
+            filePath: './TestAdapterForGoogleTest/GoogleTestAdapter/SetVersion.ps1'
             arguments: '-version 1.17.0.30'
         - task: PowerShell@1
           displayName: Add Keys for RealSign to TAfGT
@@ -156,14 +154,14 @@ extends:
             scriptType: inlineScript
             inlineScript: |-
               $projects_to_sign = @(
-                "GoogleTestAdapter\Common\Common.csproj",
-                "GoogleTestAdapter\Common.Dynamic.TAfGT\Common.Dynamic.TAfGT.csproj",
-                "GoogleTestAdapter\Core\Core.csproj",
-                "GoogleTestAdapter\DiaResolver\DiaResolver.csproj",
-                "GoogleTestAdapter\NewProjectWizard\NewProjectWizard.csproj",
-                "GoogleTestAdapter\TestAdapter\TestAdapter.csproj",
-                "GoogleTestAdapter\VsPackage.TAfGT\VsPackage.TAfGT.csproj",
-                "GoogleTestAdapter\Packaging.TAfGT\Packaging.TAfGT.csproj"
+                "TestAdapterForGoogleTest\GoogleTestAdapter\Common\Common.csproj",
+                "TestAdapterForGoogleTest\GoogleTestAdapter\Common.Dynamic.TAfGT\Common.Dynamic.TAfGT.csproj",
+                "TestAdapterForGoogleTest\GoogleTestAdapter\Core\Core.csproj",
+                "TestAdapterForGoogleTest\GoogleTestAdapter\DiaResolver\DiaResolver.csproj",
+                "TestAdapterForGoogleTest\GoogleTestAdapter\NewProjectWizard\NewProjectWizard.csproj",
+                "TestAdapterForGoogleTest\GoogleTestAdapter\TestAdapter\TestAdapter.csproj",
+                "TestAdapterForGoogleTest\GoogleTestAdapter\VsPackage.TAfGT\VsPackage.TAfGT.csproj",
+                "TestAdapterForGoogleTest\GoogleTestAdapter\Packaging.TAfGT\Packaging.TAfGT.csproj"
               )
               $projects_to_sign | ForEach-Object {
                 $xml = [xml](Get-Content $_)
@@ -172,12 +170,17 @@ extends:
                 $xml | ForEach-Object { $_.Project.PropertyGroup | ForEach-Object { if ($_.Condition -like '*(RealSign)'' == ''True''') { $_.AppendChild($KeyFile) } } }
                 $xml.Save("$pwd\$_")
               }
+        - checkout: googletest
+          displayName: 'Checkout googletest ADO Repo'
+          clean: true
+          fetchDepth: 1
+          persistCredentials: true
         - task: PowerShell@1
           displayName: Add Keys for RealSign to googletest
           inputs:
-            type: inlineScript
+            scriptType: inlineScript
             inlineScript: |-
-              $build_script = 'GoogleTestNuGet\Build.ps1'
+              $build_script = 'TestAdapterForGoogleTest\GoogleTestNuGet\Build.ps1'
               $match_string = '*$DelaySign.set_InnerXML("true")*'
               (Get-Content $build_script) | ForEach-Object {
                 if ($_ -like $match_string) {
@@ -192,9 +195,9 @@ extends:
         - task: PowerShell@1
           displayName: Update token for template
           inputs:
-            type: inlineScript
+            scriptType: inlineScript
             inlineScript: |-
-              $project_template = 'GoogleTestAdapter\GoogleTestProjectTemplate\GoogleTest.vstemplate'
+              $project_template = 'TestAdapterForGoogleTest\GoogleTestAdapter\GoogleTestProjectTemplate\GoogleTest.vstemplate'
               (Get-Content $project_template) | ForEach-Object {
                 $_ -Replace "1924acebdd4c8a75", "b03f5f7f11d50a3a"
               } | Set-Content $project_template
@@ -206,14 +209,14 @@ extends:
         - task: PowerShell@1
           displayName: Build GoogleTest NuGet packages
           inputs:
-            scriptName: GoogleTestNuGet\Build.ps1
+            scriptName: TestAdapterForGoogleTest\GoogleTestNuGet\Build.ps1
             arguments: -Verbose -VSPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\"
             workingFolder: GoogleTestNuGet
             failOnStandardError: false
         - task: MSBuild@1
           displayName: Sign NuGet packages
           inputs:
-            solution: GoogleTestNuGet\googletest.SignNuGet.proj
+            solution: TestAdapterForGoogleTest\GoogleTestNuGet\googletest.SignNuGet.proj
         - task: BatchScript@1
           displayName: Set up developer command prompt environment
           inputs:
@@ -253,7 +256,7 @@ extends:
         - task: VSBuild@1
           displayName: Build GoogleTestAdapter.sln
           inputs:
-            solution: GoogleTestAdapter/GoogleTestAdapter.sln
+            solution: TestAdapterForGoogleTest/GoogleTestAdapter/GoogleTestAdapter.sln
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
             maximumCpuCount: true
@@ -272,12 +275,12 @@ extends:
           inputs:
             solution: swix/packages.config
             selectOrConfig: config
-            nugetConfigPath: NuGet.config
+            nugetConfigPath: TestAdapterForGoogleTest/NuGet.config
             packagesDirectory: ..\NugetPackages
         - task: VSBuild@1
           displayName: Build core vsmanproj
           inputs:
-            solution: swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
+            solution: TestAdapterForGoogleTest/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
             msbuildArgs: /p:ArtifactsDir=$(Build.ArtifactStagingDirectory)
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
@@ -302,13 +305,6 @@ extends:
             Contents: Packaging.TAfGT.vsix
             TargetFolder: $(Build.ArtifactStagingDirectory)\drop
           continueOnError: true
-        - task: whitesource.ws-bolt.bolt.wss.WhiteSource Bolt@1
-          displayName: 'WhiteSource Bolt'
-          continueOnError: true
-        - task: CmdLine@2
-          displayName: Set APIScan environment
-          inputs:
-            script: setx AzureServicesAuthConnectionString runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret) /m
         - task: PoliCheck@2
           inputs:
             targetType: 'F'
@@ -323,10 +319,8 @@ extends:
             toolVersion: 'Latest'
             verbosityLevel: silent
             continueOnError: true
-        - task: CmdLine@2
-          displayName: Clear APIScan environment
-          inputs:
-            script: setx AzureServicesAuthConnectionString "" /m
+          env:
+            AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
         - task: PowerShell@2
           displayName: Pull msdia symbols
           inputs:
@@ -334,7 +328,7 @@ extends:
             script: |-
               # Using symchk to pull the symbols as BinSkim cannot cope with the symbol server currently.
               # NOTE: availability of symchk depends on APIScan being pulled down first, so this step must follow APIScan and may require updates to path as APIScan is revised.
-              $symchkPath = "D:\a\_work\_gdn\packages\nuget\VisualCppTools.MicrosoftInternal.APIScan.x64.3.3.23505.0\tools\symchk.exe" 
+              $symchkPath = "D:\a\_work\_gdn\packages\nuget\VisualCppTools.MicrosoftInternal.APIScan.x64.3.3.24044.1\tools\symchk.exe" 
               if (Test-Path C:\Symbols) { Remove-Item C:\Symbols -Recurse -Force }
               Write-Host "*** x86 ***"
               & $symchkPath $(Build.ArtifactStagingDirectory)\drop\out\binaries\GoogleTestAdapter\Release\Core\x86\msdia140.dll /s srv*C:\Symbols*https://symbols_ro:$(SYMBOLS_PAT)@artifacts.dev.azure.com/microsoft/_apis/Symbol/symsrv /v
@@ -391,7 +385,12 @@ extends:
             instanceUrlForTsaV2: DEVDIV
             projectNameDEVDIV: DevDiv
             areaPath: 'DevDiv\Cpp Developer Experience\Apogee\Google Test and Boost Test integration'
-    iterationPath: DevDiv
+            iterationPath: DevDiv
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish Artifact: drop'
+          inputs:
+            path: '$(Build.ArtifactStagingDirectory)\drop'
+            artifact: drop
         - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
           displayName: Perform Cleanup Tasks
           condition: always()

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -111,7 +111,7 @@ extends:
         templateContext:
           outputs:
           - output: pipelineArtifact
-            displayName: 'Publish Artifact: drop to pipelines'
+            displayName: 'Publish Artifact: drop'
             targetPath: $(Build.ArtifactStagingDirectory)\drop
         steps:
         - checkout: self
@@ -372,11 +372,6 @@ extends:
             DropNames: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
             AccessToken: $(DropPAT)
             DropServiceUri: https://devdiv.artifacts.visualstudio.com/DefaultCollection
-        - task: 1ES.PublishPipelineArtifact@1
-          displayName: 'Publish Artifact: drop'
-          inputs:
-            path: '$(Build.ArtifactStagingDirectory)\drop'
-            artifact: drop
         - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
           displayName: Perform Cleanup Tasks
           condition: always()

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -211,7 +211,6 @@ extends:
           inputs:
             scriptName: TestAdapterForGoogleTest\GoogleTestNuGet\Build.ps1
             arguments: -Verbose -VSPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\"
-            workingFolder: GoogleTestNuGet
             failOnStandardError: false
         - task: MSBuild@1
           displayName: Sign NuGet packages

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -214,7 +214,7 @@ extends:
           displayName: Build GoogleTest NuGet packages
           inputs:
             scriptName: TestAdapterForGoogleTest\GoogleTestNuGet\Build.ps1
-            arguments: -Verbose -VSPath "$(ProgramFiles)\Microsoft Visual Studio\2019\Enterprise\"
+            arguments: -Verbose -VSPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\"
             failOnStandardError: false
         - task: MSBuild@1
           displayName: Sign NuGet packages
@@ -223,7 +223,7 @@ extends:
         - task: BatchScript@1
           displayName: Set up developer command prompt environment
           inputs:
-            filename: $(ProgramFiles)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
+            filename: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
             modifyEnvironment: true
         - task: NuGetCommand@2
           displayName: NuGet install dia amd64

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -209,7 +209,7 @@ extends:
           displayName: Build GoogleTest NuGet packages
           inputs:
             scriptName: TestAdapterForGoogleTest\GoogleTestNuGet\Build.ps1
-            arguments: -Verbose -VSPath "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\"
+            arguments: -Verbose -VSPath "$(ProgramFiles)\Microsoft Visual Studio\2019\Enterprise\"
             failOnStandardError: false
         - task: MSBuild@1
           displayName: Sign NuGet packages
@@ -218,7 +218,7 @@ extends:
         - task: BatchScript@1
           displayName: Set up developer command prompt environment
           inputs:
-            filename: C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat
+            filename: $(ProgramFiles)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
             modifyEnvironment: true
         - task: NuGetCommand@2
           displayName: NuGet install dia amd64

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -78,10 +78,10 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEngSS-MicroBuild2019-1ES
     sdl:
       sourceAnalysisPool:
-        name: VSEngSS-MicroBuild2022-1ES
+        name: VSEngSS-MicroBuild2019-1ES
       sourceRepositoriesToScan:
         exclude:
         - repository: googletest

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -5,11 +5,14 @@
 # This pipeline will be extended to the OneESPT template
 # If you are not using the E+D shared hosted pool with windows-2022, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
 # The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish Artifact: drop to pipelines' in the templateContext section.
-trigger:
-  branches:
-    include:
-    - refs/heads/dev17
-  batch: True
+trigger: none
+schedules:
+  - cron: "0 7 1 * *"
+    displayName: Monthly Run
+    branches:
+      include:
+        - refs/heads/dev17
+    always: true
 name: $(date:yyyyMMdd)$(rev:.r)
 resources:
   repositories:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -78,15 +78,15 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2019-1ES
+      name: VSEngSS-MicroBuild2022-1ES
     sdl:
       sourceAnalysisPool:
-        name: VSEngSS-MicroBuild2019-1ES
+        name: VSEngSS-MicroBuild2022-1ES
       sourceRepositoriesToScan:
         exclude:
+        - repository: googletest
         - repository: MicroBuildTemplate
         - repository: TestAdapterForGoogleTest
-        - repository: googletest
     stages:
     - stage: stage
       jobs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -362,7 +362,7 @@ extends:
           displayName: Run Tests
           inputs:
             testAssemblyVer2: |-
-              out\binaries\GoogleTestAdapter\Release\**\*.Tests.*dll
+              TestAdapterForGoogleTest\out\binaries\GoogleTestAdapter\Release\**\*.Tests.*dll
               **\*.Tests.Common.*dll
             vsTestVersion: 15.0
             runInParallel: false

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -91,7 +91,7 @@ extends:
       sourceAnalysisPool:
         name: VSEngSS-MicroBuild2019-1ES
       sourceRepositoriesToScan:
-        exclude:
+        include:
         - repository: googletest
       tsa:
         enabled: true

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -262,6 +262,7 @@ extends:
             solution: TestAdapterForGoogleTest/GoogleTestAdapter/GoogleTestAdapter.sln
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
+            clean: true
             maximumCpuCount: true
             createLogFile: true
         - task: CopyFiles@2
@@ -282,8 +283,10 @@ extends:
             packagesDirectory: ..\NugetPackages
         - task: VSBuild@1
           displayName: 'Build core vsmanproj'
+          continueOnError: True
           inputs:
             solution: TestAdapterForGoogleTest/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
+            msbuildArgs: /p:ArtifactsDir=$(Build.ArtifactStagingDirectory)
             platform: '$(BuildPlatform)'
             configuration: '$(BuildConfiguration)'
             maximumCpuCount: true

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -294,9 +294,9 @@ extends:
             configuration: '$(BuildConfiguration)'
             maximumCpuCount: true
         - task: PublishSymbols@1
-          displayName: 'Publish symbols path: '
+          displayName: 'Publish Symbols Path'
           inputs:
-            SearchPattern: out\binaries\**\*.pdb
+            SearchPattern: TestAdapterForGoogleTest\out\binaries\**\*.pdb
           continueOnError: true
         - task: CopyFiles@2
           displayName: Copy setup files to drop root
@@ -369,12 +369,6 @@ extends:
             DropNames: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
             AccessToken: $(DropPAT)
             DropServiceUri: https://devdiv.artifacts.visualstudio.com/DefaultCollection
-        - task: PublishSymbols@2
-          displayName: Publish symbols path
-          inputs:
-            SymbolsFolder: $(Build.ArtifactStagingDirectory)\drop
-            SearchPattern: '**/*.pdb'
-            SymbolServerType: TeamServices
         - task: VSTest@2
           displayName: Run Tests
           inputs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -13,14 +13,14 @@ trigger:
 name: $(date:yyyyMMdd)$(rev:.r)
 resources:
   repositories:
-  - repository: googletest
-    type: git
-    name: googletest
-    ref: refs/heads/main
   - repository: MicroBuildTemplate
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
+  - repository: googletest
+    type: git
+    name: googletest
+    ref: refs/heads/main
 variables:
 - name: ApiScanClientId
   value: 1d6a3de7-4a6a-4b75-b15d-e305293c75af
@@ -38,8 +38,6 @@ variables:
   value: "$(TAfGTBuildConfiguration)"
 - name: BuildPlatform
   value: Any CPU
-- name: CodeQL.Cadence
-  value: 0
 - name: CodeQL.Enabled
   value: true
 - name: Codeql.Language
@@ -91,9 +89,8 @@ extends:
         name: VSEngSS-MicroBuild2019-1ES
       sourceRepositoriesToScan:
         exclude:
-        - repository: googletest
         - repository: MicroBuildTemplate
-        - repository: TestAdapterForGoogleTest
+        - repository: googletest
     stages:
     - stage: stage
       jobs:
@@ -132,10 +129,11 @@ extends:
         - task: VSBuild@1
           displayName: Build ResolveTTs.proj
           inputs:
-            solution: TestAdapterForGoogleTest/ResolveTTs.proj
-            platform: $(BuildPlatform)
-            configuration: $(BuildConfiguration)
-            maximumCpuCount: true
+            solution: 'TestAdapterForGoogleTest/ResolveTTs.proj'
+            vsVersion: '16.0'
+            msbuildArgs: '-v:diag'
+            platform: '$(BuildPlatform)'
+            configuration: '$(BuildConfiguration)'
         - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
           displayName: Generate TAfGT specific sln
           inputs:

--- a/Tools/RemoveGtaProjects.ps1
+++ b/Tools/RemoveGtaProjects.ps1
@@ -5,7 +5,7 @@ $gta_guids = @(
   "4735D8CC-FA30-432D-854C-2984A7DA5DD2"
 )
 
-$sln = Get-Content .\GoogleTestAdapter\GoogleTestAdapter.sln
+$sln = Get-Content .\TestAdapterForGoogleTest\GoogleTestAdapter\GoogleTestAdapter.sln
 $is_gta_project = $false
 $gta_guids_regex = [string]::Join('|', $gta_guids)
 
@@ -22,4 +22,4 @@ $sln | ForEach-Object {
     # Add the line to the new sln file if it isn't related to GTA projects
     $_
   }
-} | Set-Content GoogleTestAdapter\GoogleTestAdapter.sln
+} | Set-Content TestAdapterForGoogleTest\GoogleTestAdapter\GoogleTestAdapter.sln

--- a/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
+++ b/swix/core/Microsoft.VisualStudio.VC.Ide.TestAdapterForGoogleTest.vsmanproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <TargetFrameworkVersion Condition="'$(MSBuildProjectExtension)' == '.vsmanproj'">v4.7.2</TargetFrameworkVersion>
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
 


### PR DESCRIPTION
Converted Google Test Adapter ADO classic pipelines for build and compliance into one centralized build/compliance pipeline for dev17. This converted pipeline now uses the new 1ES template.

Since this new pipeline also runs time-consuming compliance tasks, the new QuickBuild variable (off by default) allows you to skip those compliance tasks to quickly build and generated a .vsix.

The new flow will be to enable quick build when quickly testing an experimental vsix. When publishing a new version of TAfGT turn all variables (except Quick Build) to True.

Old build pipeline: https://devdiv.visualstudio.com/DevDiv/_build?definitionId=14461
Old compliance pipeline: https://devdiv.visualstudio.com/DevDiv/_build?definitionId=13114

Had to remove 'Pull msdia Symbols' task since the steps for building, publishing, and pulling symbols are now mixed up since there is only one pipeline. This avoids the need for a separate pipeline, plus this step is not required.
Had to modify paths to use full path including the repository name like TestAdapterForGoogleTest and googletest. This is why some scripts had to be modified to start with /TestAdapterForGoogleTest along with two TSAOptions.json files, one under the repoRoot and one under repoRoot/TestAdapterForGoogleTest .