### PR TITLE
Fix APIScan Errors

### DIFF
--- a/FilesToScan.ps1
+++ b/FilesToScan.ps1
@@ -6,11 +6,15 @@ param (
 $filesToScan = @("GoogleTestAdapter.Common.dll", "GoogleTestAdapter.Common.Dynamic.dll", "GoogleTestAdapter.Core.dll", "GoogleTestAdapter.DiaResolver.dll", "GoogleTestAdapter.TestAdapter.dll", "GoogleTestAdapter.VsPackage.TAfGT.dll", "NewProjectWizard.dll", "gtest.dll", "gtestd.dll", "gtest_main.dll", "gtest_maind.dll")
 $FilesToScanDrop = "$buildArtifactStagingDirectory/FilesToScanDrop"
 
+if (!(Test-Path -Path $FilesToScanDrop)) {
+    New-Item -ItemType Directory -Path $FilesToScanDrop | Out-Null
+}
+
 foreach ($file in $filesToScan) {
     $sourcePaths = Get-ChildItem -Path $directoryToSearch -Recurse -Include $file -File
     foreach ($sourcePath in $sourcePaths) {
         $destinationPath = Join-Path $FilesToScanDrop $sourcePath.Name
         Copy-Item $sourcePath.FullName $destinationPath
-        Write-Host "found file to scan: $file"
+        Write-Host "Found File to Scan: $file"
     }
 }

--- a/FilesToScan.ps1
+++ b/FilesToScan.ps1
@@ -1,0 +1,14 @@
+param (
+    [string]$buildArtifactStagingDirectory
+)
+
+$filesToScan = @("GoogleTestAdapter.Common.dll", "GoogleTestAdapter.Common.Dynamic.dll", "GoogleTestAdapter.Core.dll", "GoogleTestAdapter.DiaResolver.dll", "GoogleTestAdapter.TestAdapter.dll", "GoogleTestAdapter.VsPackage.TAfGT.dll", "NewProjectWizard.dll", "gtest.dll", "gtestd.dll", "gtest_main.dll", "gtest_maind.dll")
+$FilesToScanDrop = "$buildArtifactStagingDirectory/FilesToScanDrop"
+
+foreach ($file in $filesToScan) {
+    $sourcePaths = Get-ChildItem -Path "**/out/binaries/" -Recurse -Include $file -File
+    foreach ($sourcePath in $sourcePaths) {
+        $destinationPath = Join-Path $FilesToScanDrop $sourcePath.Name
+        Copy-Item $sourcePath.FullName $destinationPath
+    }
+}

--- a/FilesToScan.ps1
+++ b/FilesToScan.ps1
@@ -16,6 +16,6 @@ foreach ($file in $filesToScan) {
     foreach ($sourcePath in $sourcePaths) {
         $destinationPath = Join-Path $FilesToScanDrop $sourcePath.Name
         Copy-Item $sourcePath.FullName $destinationPath
-        Write-Host "Found File to Scan: $destinationPath"
+        Write-Host "Found File to Scan: $sourcePath"
     }
 }

--- a/FilesToScan.ps1
+++ b/FilesToScan.ps1
@@ -11,10 +11,11 @@ if (!(Test-Path -Path $FilesToScanDrop)) {
 }
 
 foreach ($file in $filesToScan) {
-    $sourcePaths = Get-ChildItem -Path $directoryToSearch -Recurse -Include $file -File
+    # Search in output directory for files we want to scan, but exclude any arm binaries.
+    $sourcePaths = Get-ChildItem -Path $directoryToSearch -Recurse -Include $file -File | Where-Object { $_.DirectoryName -notmatch '\\arm\\|\\arm64\\' }
     foreach ($sourcePath in $sourcePaths) {
         $destinationPath = Join-Path $FilesToScanDrop $sourcePath.Name
         Copy-Item $sourcePath.FullName $destinationPath
-        Write-Host "Found File to Scan: $file"
+        Write-Host "Found File to Scan: $destinationPath"
     }
 }

--- a/FilesToScan.ps1
+++ b/FilesToScan.ps1
@@ -1,14 +1,16 @@
 param (
-    [string]$buildArtifactStagingDirectory
+    [string]$buildArtifactStagingDirectory,
+    [string]$directoryToSearch
 )
 
 $filesToScan = @("GoogleTestAdapter.Common.dll", "GoogleTestAdapter.Common.Dynamic.dll", "GoogleTestAdapter.Core.dll", "GoogleTestAdapter.DiaResolver.dll", "GoogleTestAdapter.TestAdapter.dll", "GoogleTestAdapter.VsPackage.TAfGT.dll", "NewProjectWizard.dll", "gtest.dll", "gtestd.dll", "gtest_main.dll", "gtest_maind.dll")
 $FilesToScanDrop = "$buildArtifactStagingDirectory/FilesToScanDrop"
 
 foreach ($file in $filesToScan) {
-    $sourcePaths = Get-ChildItem -Path "**/out/binaries/" -Recurse -Include $file -File
+    $sourcePaths = Get-ChildItem -Path $directoryToSearch -Recurse -Include $file -File
     foreach ($sourcePath in $sourcePaths) {
         $destinationPath = Join-Path $FilesToScanDrop $sourcePath.Name
         Copy-Item $sourcePath.FullName $destinationPath
+        Write-Host "found file to scan: $file"
     }
 }

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -134,6 +134,18 @@ function Add-Signing {
     $MicroBuildProps.SetAttribute("Project", "$microbuild\build\Microsoft.VisualStudioEng.MicroBuild.Core.props")
     $MicroBuildProps.SetAttribute("Condition", "Exists('$microbuild\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')")
 
+    $BuildGroup = $xml.CreateElement("ItemDefinitionGroup", "http://schemas.microsoft.com/developer/msbuild/2003")
+    $ClCompile = $xml.CreateElement("ClCompile", "http://schemas.microsoft.com/developer/msbuild/2003")
+    $AdditionalOptions = $xml.CreateElement("Profile", "http://schemas.microsoft.com/developer/msbuild/2003")
+    $AdditionalOptions.set_InnerXML("/Zi %(AdditionalOptions)");
+    $ClCompile.AppendChild($AdditionalOptions) | Out-Null
+    $Link = $xml.CreateElement("Link", "http://schemas.microsoft.com/developer/msbuild/2003")
+    $Profile = $xml.CreateElement("Profile", "http://schemas.microsoft.com/developer/msbuild/2003")
+    $Profile.set_InnerXML("true");
+    $Link.AppendChild($Profile) | Out-Null
+    $BuildGroup.AppendChild($ClCompile) | Out-Null
+    $BuildGroup.AppendChild($Link) | Out-Null
+
     $RealSignGroup = $xml.CreateElement("PropertyGroup", "http://schemas.microsoft.com/developer/msbuild/2003")
     $RealSignGroup.SetAttribute("Condition", "'`$(RealSign)' == 'True'")
     $SignAsm = $xml.CreateElement("SignAssembly", "http://schemas.microsoft.com/developer/msbuild/2003")
@@ -170,6 +182,7 @@ function Add-Signing {
     $MicroBuildTargets.SetAttribute("Condition", "Exists('$microbuild\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')")
 
     $xml.Project.AppendChild($MicroBuildProps) | Out-Null
+    $xml.Project.AppendChild($BuildGroup) | Out-Null
     $xml.Project.AppendChild($RealSignGroup) | Out-Null
     $xml.Project.AppendChild($FileSignGroup) | Out-Null
     $xml.Project.AppendChild($MicroBuildTargets) | Out-Null

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -292,6 +292,12 @@ function Build-NuGet {
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest_main.dll" -Destination "$DestinationPath\Release\gtest_main.dll"
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest_main.lib" -Destination "$DestinationPath\Release\gtest_main.lib"
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest_main.pdb" -Destination "$DestinationPath\Release\gtest_main.pdb"
+
+            # Copy gtest dlls to drop artifacts folder for scanning.
+            Copy-CreateItem -Path "$BuildPath\Debug\gtestd.dll"              -Destination "..\a\drop\gtestd.dll"
+            Copy-CreateItem -Path "$BuildPath\Debug\gtest_maind.dll"         -Destination "..\a\drop\gtest_maind.dll"
+            Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest.dll"      -Destination "..\a\drop\gtest.dll"
+            Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest_main.dll" -Destination "..\a\drop\gtest_main.dll"
         } else {
             Copy-CreateItem -Path "$BuildPath\Debug\gtestd.lib"                    -Destination "$DestinationPath\Debug\gtestd.lib"
             Copy-CreateItem -Path "$BuildPath\gtest.dir\Debug\gtest.pdb"           -Destination "$DestinationPath\Debug\gtest.pdb"

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -283,10 +283,12 @@ function Build-NuGet {
     Copy-Item -Recurse -Path "googletest\googletest\include" -Destination "$Dir\build\native\include"
 
     $BuildToDestinationPath = @()
-    $BuildToDestinationPath += ,@($BuildDir32, "$Dir\$PathToBinaries\x86")
-    $BuildToDestinationPath += ,@($BuildDir64, "$Dir\$PathToBinaries\x64")
     $BuildToDestinationPath += ,@($BuildDirARM64, "$Dir\$PathToBinaries\arm64")
     $BuildToDestinationPath += ,@($BuildDirARM, "$Dir\$PathToBinaries\arm")
+    $BuildToDestinationPath += ,@($BuildDir32, "$Dir\$PathToBinaries\x86")
+
+    # Build x64 last to ensure that the supported x64 binaries are copied to the drop folder for scanning.
+    $BuildToDestinationPath += ,@($BuildDir64, "$Dir\$PathToBinaries\x64")
     $BuildToDestinationPath | ForEach-Object {
         $BuildPath = $_[0]
         $DestinationPath = $_[1]
@@ -311,6 +313,14 @@ function Build-NuGet {
             Copy-CreateItem -Path "$BuildPath\Debug\gtest_maind.dll"         -Destination "..\a\drop\gtest_maind.dll"
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest.dll"      -Destination "..\a\drop\gtest.dll"
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest_main.dll" -Destination "..\a\drop\gtest_main.dll"
+
+            if ((Get-Item "$BuildPath\RelWithDebInfo\gtest.dll").VersionInfo.FileDescription -like "*x64*") {
+                Write-Verbose "Found x64 dll"
+            }
+            else{
+                Write-Verbose "Non-x64 dll encountered"
+            }
+
         } else {
             Copy-CreateItem -Path "$BuildPath\Debug\gtestd.lib"                    -Destination "$DestinationPath\Debug\gtestd.lib"
             Copy-CreateItem -Path "$BuildPath\gtest.dir\Debug\gtest.pdb"           -Destination "$DestinationPath\Debug\gtest.pdb"

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -309,8 +309,6 @@ function Build-NuGet {
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest_main.pdb" -Destination "$DestinationPath\Release\gtest_main.pdb"
 
             # Copy gtest dlls to drop artifacts folder for scanning.
-            Copy-CreateItem -Path "$BuildPath\Debug\gtestd.dll"              -Destination "..\a\drop\gtestd.dll"
-            Copy-CreateItem -Path "$BuildPath\Debug\gtest_maind.dll"         -Destination "..\a\drop\gtest_maind.dll"
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest.dll"      -Destination "..\a\drop\gtest.dll"
             Copy-CreateItem -Path "$BuildPath\RelWithDebInfo\gtest_main.dll" -Destination "..\a\drop\gtest_main.dll"
 

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -330,7 +330,7 @@ extends:
           displayName: 'Copy Scannable Files to: $(Build.ArtifactStagingDirectory)\FilesToScanDrop'
           inputs:
             filePath: './TestAdapterForGoogleTest/FilesToScan.ps1'
-            arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory) -directoryToSearch $(Build.SourcesDirectory)\TestAdapterForGoogleTest\out\binaries\'
+            arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory) -directoryToSearch $(Build.ArtifactStagingDirectory)\drop'
         # Debug task for now to verify what files are in this FilesToScanDrop.
         - task: 1ES.PublishPipelineArtifact@1
           displayName: 'Publish Artifact: FilesToScanDrop'

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -330,7 +330,7 @@ extends:
           displayName: 'Copy Scannable Files to: $(Build.ArtifactStagingDirectory)\FilesToScanDrop'
           inputs:
             filePath: './TestAdapterForGoogleTest/FilesToScan.ps1'
-            arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
+            arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory) -directoryToSearch $(Build.SourcesDirectory)\TestAdapterForGoogleTest\out\binaries\'
         # Debug task for now to verify what files are in this FilesToScanDrop.
         - task: 1ES.PublishPipelineArtifact@1
           displayName: 'Publish Artifact: FilesToScanDrop'

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -325,6 +325,18 @@ extends:
             Contents: Packaging.TAfGT.vsix
             TargetFolder: $(Build.ArtifactStagingDirectory)\drop
           continueOnError: true
+        # Pull a list only of files we build and ship to be scanned in FilesToScanDrop.
+        - task: PowerShell@2
+          displayName: 'Copy Scannable Files to: $(Build.ArtifactStagingDirectory)\FilesToScanDrop'
+          inputs:
+            filePath: './TestAdapterForGoogleTest/FilesToScan.ps1'
+            arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
+        # Debug task for now to verify what files are in this FilesToScanDrop.
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish Artifact: FilesToScanDrop'
+          inputs:
+            path: '$(Build.ArtifactStagingDirectory)\FilesToScanDrop'
+            artifact: FilesToScanDrop
         # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: PoliCheck@2
           displayName: 'PoliCheck'
@@ -337,7 +349,7 @@ extends:
           displayName: 'Run APIScan'
           condition: eq (variables.QuickBuild, False)
           inputs:
-            softwareFolder: '$(Build.ArtifactStagingDirectory)\drop'
+            softwareFolder: '$(Build.ArtifactStagingDirectory)\FilesToScanDrop'
             softwareName: GoogleTest
             softwareVersionNum: 1.0
             isLargeApp: false


### PR DESCRIPTION
Updates build+compliance pipeline to have a new FilesToScanDrop that only contains the absolutely necessary binaries we want to be scanned by APIScan. Also, added flags when building gtest nuget packages to make sure they are Vulkan ready so they can also be scanned by APIScan. Now, we are only scanning a specific list of binaries that we own, build, and ship. We also only scan retail binaries in the supported x64 configuration. 