### PR TITLE
Fix binskim errors by scanning only necessary binaries

### DIFF
--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -111,6 +111,7 @@ extends:
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
+        analyzeTargetGlob: '$(Build.ArtifactStagingDirectory)\FilesToScanDrop\**\*.dll'
     customBuildTags:
     - ES365AIMigrationTooling
     stages:


### PR DESCRIPTION
Misconfiguration of Binskim. Now scanning new FilesToScanDrop which only contains files we want scanned that we own, build, and ship.