### PR TITLE
Fix Real Signing and PoliCheck

### DIFF
--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -68,8 +68,8 @@ variables:
   # Quick build is used to skip some compliance tasks to quickly generate a .vsix for testing.
 - name: QuickBuild
   value: "$(TAfGTQuickBuild)"
-- name: RealSign
-  value: "$(TAfGTRealSign)"
+- name: TAfGTRealSign
+  value: "$(RealSign)"
 - name: RetainBuild
   value: "$(TAfGTRetainBuild)"
 - name: SignType
@@ -144,7 +144,7 @@ extends:
           persistCredentials: true
         - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
           displayName: Install Localization Plugin
-        - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+        - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
           displayName: Install Signing Plugin
           inputs:
             signType: $(SignType)

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -347,11 +347,18 @@ extends:
             arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory) -directoryToSearch $(Build.ArtifactStagingDirectory)\drop'
         # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: PoliCheck@2
-          displayName: 'PoliCheck'
+          displayName: 'PoliCheck on TestAdapterForGoogleTest repo'
           condition: eq (variables.QuickBuild, False)
           inputs:
             targetType: 'F'
-            targetArgument: '$(Build.SourcesDirectory)'
+            targetArgument: '$(Build.SourcesDirectory)/TestAdapterForGoogleTest'
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
+        - task: PoliCheck@2
+          displayName: 'PoliCheck on googletest repo'
+          condition: eq (variables.QuickBuild, False)
+          inputs:
+            targetType: 'F'
+            targetArgument: '$(Build.SourcesDirectory)/googletest'
         # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
           displayName: 'Run APIScan'


### PR DESCRIPTION
Fix signing by using latest install signing plugin task
We do not need to scan VCLS-Extensions repo by default since we only checkout that repo to copy the public signing key. Now, we only manually scan TestAdapterForGoogleTest and googletest repos for PoliCheck.