### PR TITLE
Update TSAOptions.json path to fix CodeQL reporting

### DIFF
--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -61,6 +61,8 @@ variables:
   value: csharp
 - name: CodeQL.TSAEnabled
   value: true
+- name: Codeql.TSAOptionsPath
+  value: $(Build.SourcesDirectory)\TestAdapterForGoogleTest\TSAOptions.json
 - name: DiaNugetVersion
   value: "$(TAfGTDiaNugetVersion)"
 - name: DropRoot
@@ -117,7 +119,7 @@ extends:
         - repository: VCLS-Extensions
       tsa:
         enabled: true
-        configFile: '$(Build.SourcesDirectory)\tsaoptions.json'
+        configFile: '$(Build.SourcesDirectory)\TSAOptions.json'
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true


### PR DESCRIPTION
Update CodeQL variable to to know where to look for for TSAOptions.json. Since this pipeline checks out more than one repo it is not in the default location of Build.SourcesDirectory, but rather in Build.SourcesDirectory/TestAdapterForGoogleTest. Repo names have to be specified in paths when pipelines check out multiple repos.