### PR TITLE
Use VS 2022 for building

### DIFF
--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -207,7 +207,7 @@ function Build-Binaries {
     Push-Location $Dir
     try {
         $CMakeArgs = @()
-        $CMakeArgs += "-G", "Visual Studio 16 2019"
+        $CMakeArgs += "-G", "Visual Studio 17 2022"
         $CMakeArgs += "-T", $BuildToolset
         $CMakeArgs += "-A", $Platform
         $CMakeArgs += "-D", "BUILD_SHARED_LIBS=$(Convert-BooleanToOnOff $DynamicLibraryLinkage)"

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -363,6 +363,13 @@ extends:
           inputs:
             filePath: './FilesToScan.ps1'
             arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory) -directoryToSearch $(Build.ArtifactStagingDirectory)\drop'
+        - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+          displayName: Detect components for googletest repo
+          inputs:
+            sourceScanPath: '$(Build.SourcesDirectory)/googletest'
+            scanType: 'Register'
+            verbosity: 'Verbose'
+            alertWarningLevel: 'High'
         # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: PoliCheck@2
           displayName: 'PoliCheck on TestAdapterForGoogleTest repo'

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -100,7 +100,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2019-1ES
+      name: VSEngSS-MicroBuild2022-1ES
       demands:
       - vstest
       - msbuild
@@ -110,7 +110,7 @@ extends:
       - npm
     sdl:
       sourceAnalysisPool:
-        name: VSEngSS-MicroBuild2019-1ES
+        name: VSEngSS-MicroBuild2022-1ES
       sourceRepositoriesToScan:
         include:
         - repository: googletest
@@ -176,7 +176,7 @@ extends:
           displayName: Build ResolveTTs.proj
           inputs:
             solution: 'ResolveTTs.proj'
-            vsVersion: '16.0'
+            vsVersion: '17.0'
             msbuildArgs: '-v:diag'
             platform: '$(BuildPlatform)'
             configuration: '$(BuildConfiguration)'
@@ -262,7 +262,7 @@ extends:
           displayName: Build GoogleTest NuGet packages
           inputs:
             scriptName: GoogleTestNuGet\Build.ps1
-            arguments: -Verbose -VSPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\"
+            arguments: -Verbose -VSPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\"
             failOnStandardError: false
         - task: MSBuild@1
           displayName: Sign NuGet packages
@@ -271,7 +271,7 @@ extends:
         - task: BatchScript@1
           displayName: Set up developer command prompt environment
           inputs:
-            filename: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat
+            filename: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat
             modifyEnvironment: true
         - task: NuGetCommand@2
           displayName: NuGet install dia amd64


### PR DESCRIPTION
Use latest VS 2022 for building and enable manual task to run Component Governance for googletest repo