### PR TITLE
Add PreFast scanning and Fix PoliCheck Bugs

### DIFF
--- a/SampleTests/3rdparty/gtest-1.8.0/fused-src/gtest/gtest.h
+++ b/SampleTests/3rdparty/gtest-1.8.0/fused-src/gtest/gtest.h
@@ -599,7 +599,7 @@
 #if GTEST_LANG_CXX11 && \
     (!defined(__GLIBCXX__) || ( \
         __GLIBCXX__ >= 20110325ul &&  /* GCC >= 4.6.0 */ \
-        /* Blacklist of patch releases of older branches: */ \
+        /* Denylist of patch releases of older branches: */ \
         __GLIBCXX__ != 20110416ul &&  /* GCC 4.4.6 */ \
         __GLIBCXX__ != 20120313ul &&  /* GCC 4.4.7 */ \
         __GLIBCXX__ != 20110428ul &&  /* GCC 4.5.3 */ \

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -360,6 +360,17 @@ extends:
             filePath: './FilesToScan.ps1'
             arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory) -directoryToSearch $(Build.ArtifactStagingDirectory)\drop'
         # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
+        - task: SDLNativeRules@3
+          displayName: 'Run the PREfast SDL Native Rules for MSBuild'
+          condition: eq (variables.RunAdditionalComplianceChecks, True)
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          inputs:
+            publishXML: true
+            userProvideBuildInfo: auto
+            rulesetName: Recommended
+            setupCommandlinePicker: 'vs2022'
+        # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: PoliCheck@2
           displayName: 'PoliCheck on TestAdapterForGoogleTest repo'
           condition: eq (variables.RunAdditionalComplianceChecks, True)


### PR DESCRIPTION
Since these pipelines checkout other repos, then when it scans the source it will scan everything rather than just the one repo we want.

For example, the TAfGT pipeline should only scan the TAfGT repo, but since we also checkout the googletest repo when building and the VCLS_Extensions when signing, then it also tries to scan all that source code. The scans for those repos should be done in their own individual pipelines that belong to those repos, or we'll get lots of duplicate bugs.

You can see we do the same for PoliCheck task where we use the manual task rather than the auto-injected one so that we can scan only the repo we want. 