### PR TITLE
Component Governance: Downgrade Moq package version

### DIFF
--- a/GoogleTestAdapter/Core.Tests/Core.Tests.csproj
+++ b/GoogleTestAdapter/Core.Tests/Core.Tests.csproj
@@ -45,7 +45,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="5.1.1" PrivateAssets="all" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" PrivateAssets="all" />
-    <PackageReference Include="Moq" Version="4.20.69" PrivateAssets="all" />
+    <PackageReference Include="Moq" Version="4.18.4" PrivateAssets="all" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.XML" />

--- a/GoogleTestAdapter/DiaResolver.Tests/DiaResolver.Tests.csproj
+++ b/GoogleTestAdapter/DiaResolver.Tests/DiaResolver.Tests.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="5.1.1" PrivateAssets="all" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Moq" Version="4.20.69" PrivateAssets="all" />
+    <PackageReference Include="Moq" Version="4.18.4" PrivateAssets="all" />
     <Reference Include="FluentAssertions.Core">
       <HintPath>$(PkgFluentAssertions)\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>

--- a/GoogleTestAdapter/TestAdapter.Tests/TestAdapter.Tests.csproj
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestAdapter.Tests.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.10.0-release-20210330-02" />
     <PackageReference Include="Castle.Core" Version="5.1.1" Private="true" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" Private="true" GeneratePathProperty="true" />
-    <PackageReference Include="Moq" Version="4.20.69" Private="true" />
+    <PackageReference Include="Moq" Version="4.18.4" Private="true" />
     <Reference Include="FluentAssertions.Core">
       <HintPath>$(PkgFluentAssertions)\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>

--- a/GoogleTestAdapter/Tests.Common/Tests.Common.csproj
+++ b/GoogleTestAdapter/Tests.Common/Tests.Common.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="LovettSoftware.XmlDiff">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" Private="true" />
+    <PackageReference Include="Moq" Version="4.18.4" Private="true" />
     <Reference Include="FluentAssertions.Core">
       <HintPath>$(PkgFluentAssertions)\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
Component Governance is flagging the dependency with a security alert and the guidance is to pin the version to the previous 4.18.20.

Fix: #1976469