### PR TITLE
Make better trait name for google test to avoid conflict.

### DIFF
--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -66,7 +66,7 @@ namespace GoogleTestAdapter.Runners
                         {
                             var key = Path.GetFullPath(testCase.Source) + ":" + testCase.FullyQualifiedName;
 
-                            var testType = testCase.Traits.FirstOrDefault(t => t.Name.Equals(nameof(TestCaseDescriptor.TestType)));
+                            var testType = testCase.Traits.FirstOrDefault(t => t.Name.Equals(TestCaseDescriptor.TestTypeTraitName));
 
                             // If it is a parameterized test, we should look for the "parent" key which doesn't have the suite or the id defined in the xml file. 
                             // The strategy for this can also be seen in the MethodSignatureCreate.cs file, going the other way.

--- a/GoogleTestAdapter/Core/TestCases/TestCaseDescriptor.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseDescriptor.cs
@@ -11,6 +11,8 @@
         public string DisplayName { get; }
         public TestTypes TestType { get; }
 
+        internal const string TestTypeTraitName = "GoogleTestAdapter.TestType";
+
         internal TestCaseDescriptor(string suite, string name, string fullyQualifiedName, string displayName, TestTypes testType)
         {
             Suite = suite;

--- a/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
@@ -236,7 +236,7 @@ namespace GoogleTestAdapter.TestCases
             testCase.Traits.AddRange(GetFinalTraits(descriptor.DisplayName, new List<Trait>()));
 
             // Add the TestType for use in the executor when constructing the test key.
-            testCase.Traits.Add(new Trait(nameof(TestCaseDescriptor.TestType), descriptor.TestType.ToString()));
+            testCase.Traits.Add(new Trait(TestCaseDescriptor.TestTypeTraitName, descriptor.TestType.ToString()));
             return testCase;
         }
 
@@ -266,7 +266,7 @@ namespace GoogleTestAdapter.TestCases
                 testCase.Traits.AddRange(GetFinalTraits(descriptor.DisplayName, location.Traits));
 
                 // Add the TestType for use in the executor when constructing the test key.
-                testCase.Traits.Add(new Trait(nameof(TestCaseDescriptor.TestType), descriptor.TestType.ToString()));
+                testCase.Traits.Add(new Trait(TestCaseDescriptor.TestTypeTraitName, descriptor.TestType.ToString()));
                 return testCase;
             }
 
@@ -274,7 +274,7 @@ namespace GoogleTestAdapter.TestCases
                 descriptor.FullyQualifiedName, descriptor.FullyQualifiedName, _executable, descriptor.DisplayName, "", 0);
 
             // Add the TestType for use in the executor when constructing the test key.
-            returnTest.Traits.Add(new Trait(nameof(TestCaseDescriptor.TestType), descriptor.TestType.ToString()));
+            returnTest.Traits.Add(new Trait(TestCaseDescriptor.TestTypeTraitName, descriptor.TestType.ToString()));
             _logger.LogWarning(String.Format(Resources.LocationNotFoundError, descriptor.FullyQualifiedName));
             return returnTest;
         }


### PR DESCRIPTION
There was an issue where the trait name `TestType` was clashing with a legacy test adapter. 

See here: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2085822