### PR TITLE
Make TestTypeTraitName static and remove dot to fix regression

### DIFF
--- a/GoogleTestAdapter/Core/TestCases/TestCaseDescriptor.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseDescriptor.cs
@@ -2,6 +2,8 @@
 {
     public class TestCaseDescriptor
     {
+        public static string TestTypeTraitName = "GoogleTestAdapterTestType";
+
         public enum TestTypes { Simple, Parameterized, TypeParameterized }
 
         public string Suite { get; }
@@ -10,8 +12,6 @@
         public string FullyQualifiedName { get; }
         public string DisplayName { get; }
         public TestTypes TestType { get; }
-
-        internal const string TestTypeTraitName = "GoogleTestAdapter.TestType";
 
         internal TestCaseDescriptor(string suite, string name, string fullyQualifiedName, string displayName, TestTypes testType)
         {


### PR DESCRIPTION
Regression caused by this PR: https://github.com/microsoft/TestAdapterForGoogleTest/pull/272/files
Broke discovery/execution by throwing an error caused by trying to access TestTypeTraitName (internal) from a different assembly.
Either that or the dot "." in the trait name was causing issues, but unlikely.