### PR TITLE
Fix Loc Bugs, fix CodeQL Hang, and Pipeline/Task Updates

### DIFF
--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -156,7 +156,7 @@ extends:
           inputs:
             SourceFolder: '$(Build.SourcesDirectory)\TestAdapterForGoogleTest'
             TargetFolder: '$(Build.SourcesDirectory)'
-        - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
+        - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@4
           displayName: Install Localization Plugin
         - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
           displayName: Install Signing Plugin

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -344,14 +344,11 @@ extends:
             platform: '$(BuildPlatform)'
             configuration: '$(BuildConfiguration)'
             maximumCpuCount: true
-        - task: PublishSymbols@2
+        - task: PublishSymbols@1
           displayName: 'Publish Symbols Path'
           inputs:
-            inputs:
-            SymbolsFolder: $(Build.ArtifactStagingDirectory)\drop
-            SearchPattern: '**/*.pdb'
-            SymbolServerType: 'TeamServices'
-            TreatNotIndexedAsWarning: true
+            SearchPattern: out\binaries\**\*.pdb
+          continueOnError: true
         - task: CopyFiles@2
           displayName: Copy setup files to drop root
           inputs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -176,11 +176,11 @@ extends:
             msbuildArgs: '-v:diag'
             platform: '$(BuildPlatform)'
             configuration: '$(BuildConfiguration)'
-        - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
+        - task: PowerShell@2
           displayName: Generate TAfGT specific sln
           inputs:
-            type: FilePath
-            scriptName: Tools\RemoveGtaProjects.ps1
+            targetType: filePath
+            filePath: Tools\RemoveGtaProjects.ps1
         - task: NuGetCommand@2
           displayName: NuGet restore to sign packages
           inputs:
@@ -200,10 +200,10 @@ extends:
             targetType: filePath
             filePath: './GoogleTestAdapter/SetVersion.ps1'
             arguments: '-version $(VersionNumber)'
-        - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
+        - task: PowerShell@2
           displayName: Add Keys for RealSign to TAfGT
           inputs:
-            type: InlineScript
+            targetType: inline
             script: |-
               $projects_to_sign = @(
                 "GoogleTestAdapter\Common\Common.csproj",
@@ -222,10 +222,10 @@ extends:
                 $xml | ForEach-Object { $_.Project.PropertyGroup | ForEach-Object { if ($_.Condition -like '*(RealSign)'' == ''True''') { $_.AppendChild($KeyFile) } } }
                 $xml.Save("$pwd\$_")
               }
-        - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
+        - task: PowerShell@2
           displayName: Add Keys for RealSign to googletest
           inputs:
-            type: InlineScript
+            targetType: inline
             script: |-
               $build_script = 'GoogleTestNuGet\Build.ps1'
               $match_string = '*$DelaySign.set_InnerXML("true")*'
@@ -239,10 +239,10 @@ extends:
                   $_
                 }
               } | Set-Content $build_script
-        - task: ms-devlabs.utilitytasks.task-PSpp.Powershellpp@0
+        - task: PowerShell@2
           displayName: Update token for template
           inputs:
-            type: InlineScript
+            targetType: inline
             script: |-
               $project_template = 'GoogleTestAdapter\GoogleTestProjectTemplate\GoogleTest.vstemplate'
               (Get-Content $project_template) | ForEach-Object {
@@ -254,10 +254,11 @@ extends:
             SourceFolder: '$(Build.SourcesDirectory)/VCLS-Extensions/InternalAPIs/DevDiv'
             Contents: 'FinalPublicKey.snk'
             TargetFolder: '$(Build.SourcesDirectory)'
-        - task: PowerShell@1
+        - task: PowerShell@2
           displayName: Build GoogleTest NuGet packages
           inputs:
-            scriptName: GoogleTestNuGet\Build.ps1
+            targetType: filePath
+            filePath: GoogleTestNuGet\Build.ps1
             arguments: -Verbose -VSPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\"
             failOnStandardError: false
         - task: MSBuild@1

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -120,6 +120,8 @@ extends:
         enabled: true
         scanOutputDirectoryOnly: true
         analyzeTargetGlob: '$(Build.ArtifactStagingDirectory)\FilesToScanDrop\**\*.dll'
+      codeSignValidation:
+        additionalTargetsGlobPattern: +|$(Build.ArtifactStagingDirectory)\FilesToScanDrop\** # Include only the files we own, build, and ship (located in /FilesToScanDrop). All other dependency binaries shipped in the .vsix are already signed by Microsoft directly.
     customBuildTags:
     - ES365AIMigrationTooling
     stages:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -172,7 +172,7 @@ extends:
           displayName: Build ResolveTTs.proj
           inputs:
             solution: 'ResolveTTs.proj'
-            vsVersion: '16.0'
+            vsVersion: 'latest'
             msbuildArgs: '-v:diag'
             platform: '$(BuildPlatform)'
             configuration: '$(BuildConfiguration)'

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -334,11 +334,14 @@ extends:
             platform: '$(BuildPlatform)'
             configuration: '$(BuildConfiguration)'
             maximumCpuCount: true
-        - task: PublishSymbols@1
+        - task: PublishSymbols@2
           displayName: 'Publish Symbols Path'
           inputs:
-            SearchPattern: out\binaries\**\*.pdb
-          continueOnError: true
+            inputs:
+            SymbolsFolder: $(Build.ArtifactStagingDirectory)\drop
+            SearchPattern: '**/*.pdb'
+            SymbolServerType: 'TeamServices'
+            TreatNotIndexedAsWarning: true
         - task: CopyFiles@2
           displayName: Copy setup files to drop root
           inputs:

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -122,6 +122,10 @@ extends:
         analyzeTargetGlob: '$(Build.ArtifactStagingDirectory)\FilesToScanDrop\**\*.dll'
       codeSignValidation:
         additionalTargetsGlobPattern: +|$(Build.ArtifactStagingDirectory)\FilesToScanDrop\** # Include only the files we own, build, and ship (located in /FilesToScanDrop). All other dependency binaries shipped in the .vsix are already signed by Microsoft directly.
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: 'There is a bug in the 1ES template that auto injects multiple CodeQL Initialize tasks when checking out multiple repos. This causes an endless CodeQL hang during pipeline builds.'
     customBuildTags:
     - ES365AIMigrationTooling
     stages:
@@ -170,6 +174,9 @@ extends:
           displayName: Install NuGet
           inputs:
             versionSpec: 5.9.1
+        # Have to use manual CodeQL Init task for now because the 1ES template auto injected CodeQL contains bug that hangs during pipeline builds.
+        - task: MS-CST-E.codeql-3000-release.init-task.CodeQL3000Init@0
+          displayName: CodeQL 3000 Init
         - task: VSBuild@1
           displayName: Build ResolveTTs.proj
           inputs:
@@ -397,6 +404,9 @@ extends:
             continueOnError: true
           env:
             AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
+        # Have to use manual CodeQL Init task for now because the 1ES template auto injected CodeQL contains bug that hangs during pipeline builds.
+        - task: MS-CST-E.codeql-3000-release.finalize-task.CodeQL3000Finalize@0
+          displayName: CodeQL 3000 Finalize
         # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
           displayName: 'Publish Guardian Artifacts'

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -121,7 +121,7 @@ extends:
         scanOutputDirectoryOnly: true
         analyzeTargetGlob: '$(Build.ArtifactStagingDirectory)\FilesToScanDrop\**\*.dll'
       codeSignValidation:
-        additionalTargetsGlobPattern: +|$(Build.ArtifactStagingDirectory)\FilesToScanDrop\** # Include only the files we own, build, and ship (located in /FilesToScanDrop). All other dependency binaries shipped in the .vsix are already signed by Microsoft directly.
+        additionalTargetsGlobPattern: -:f|$(Build.ArtifactStagingDirectory)\drop\** # Include only the files we own, build, and ship (located in /FilesToScanDrop). All other dependency binaries shipped in the .vsix are already signed by Microsoft directly.
       codeql:
         compiled:
           enabled: false

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -134,6 +134,12 @@ extends:
           - output: pipelineArtifact
             displayName: 'Publish Artifact: drop'
             targetPath: $(Build.ArtifactStagingDirectory)\drop
+          mb:
+            signing:
+              enabled: true
+              signType: $(SignType)
+            localization:
+              enabled: true
         steps:
         - checkout: self
           displayName: 'Checkout TestAdapterForGoogleTest Git Repo'
@@ -156,12 +162,6 @@ extends:
           inputs:
             SourceFolder: '$(Build.SourcesDirectory)\TestAdapterForGoogleTest'
             TargetFolder: '$(Build.SourcesDirectory)'
-        - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@4
-          displayName: Install Localization Plugin
-        - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
-          displayName: Install Signing Plugin
-          inputs:
-            signType: $(SignType)
         - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@4
           displayName: Install Swix Plugin
         - task: NuGetToolInstaller@1


### PR DESCRIPTION
- Update to latest tasks for Publishing Symbols and Installing Localization Plugin to fix localization regression bugs.
   - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2089662 
   - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2045221
   - https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2033102
   - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2060209
- Use manual CodeQL tasks rather than 1ES auto injected CodeQL tasks. Since this pipeline checks out multiple repositories the 1ES template auto injects multiple CodeQL Initialize tasks which causes an endless hang during the build task. This is a known bug by 1ES that they are working on, so this was the suggested workaround for now. 
- Disable Code Sign Validation for /drop for now since explicitly scanning /FilestoScanDrop doesn't work right now
- Use auto injected template tasks for signing and localization plugins.
- Update some build and powershell tasks to use the latest version