### PR TITLE
Fix CodeSign Validation to only sign /FilesToScanDrop

### DIFF
--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -119,9 +119,9 @@ extends:
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
-        analyzeTargetGlob: '$(Build.ArtifactStagingDirectory)\FilesToScanDrop\**\*.dll'
+        analyzeTargetGlob: '$(Build.ArtifactStagingDirectory)\drop\FilesToScanDrop\**\*.dll'
       codeSignValidation:
-        additionalTargetsGlobPattern: -:f|$(Build.ArtifactStagingDirectory)\drop\** # Include only the files we own, build, and ship (located in /FilesToScanDrop). All other dependency binaries shipped in the .vsix are already signed by Microsoft directly.
+        additionalTargetsGlobPattern: -:f|$(Build.ArtifactStagingDirectory)\drop\out\**;-:f|$(Build.ArtifactStagingDirectory)\drop\_manifest\**;-:f|$(Build.ArtifactStagingDirectory)\drop\gdn-Packaging.TAfGT.vsix\**;-:f|$(Build.ArtifactStagingDirectory)\drop\*.dll # Include only the files we own, build, and ship (located in /FilesToScanDrop). All other dependency binaries shipped in the .vsix are already signed by Microsoft directly.
       codeql:
         compiled:
           enabled: false
@@ -365,10 +365,10 @@ extends:
           continueOnError: true
         # Pull a list only of files we build and ship to be scanned in FilesToScanDrop.
         - task: PowerShell@2
-          displayName: 'Copy Scannable Files to: $(Build.ArtifactStagingDirectory)\FilesToScanDrop'
+          displayName: 'Copy Scannable Files to: $(Build.ArtifactStagingDirectory)\drop\FilesToScanDrop'
           inputs:
             filePath: './FilesToScan.ps1'
-            arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory) -directoryToSearch $(Build.ArtifactStagingDirectory)\drop'
+            arguments: '-buildArtifactStagingDirectory $(Build.ArtifactStagingDirectory)\drop -directoryToSearch $(Build.ArtifactStagingDirectory)\drop'
         # This is a time-consuming compliance task, so if we want to run a quick build (off by default), then we skip this task.
         - task: SDLNativeRules@3
           displayName: 'Run the PREfast SDL Native Rules for MSBuild'
@@ -392,7 +392,7 @@ extends:
           displayName: 'Run APIScan'
           condition: eq (variables.RunAdditionalComplianceChecks, True)
           inputs:
-            softwareFolder: '$(Build.ArtifactStagingDirectory)\FilesToScanDrop'
+            softwareFolder: '$(Build.ArtifactStagingDirectory)\drop\FilesToScanDrop'
             softwareName: GoogleTest
             softwareVersionNum: 1.0
             isLargeApp: false


### PR DESCRIPTION
Disable CodeSign Validation scanning for all files in /drop and only scan /FilesToScanDrop
/FilesToScanDrop includes only the files we own, build, and ship. All other dependency binaries shipped in the .vsix are already signed by Microsoft directly.