### PR TITLE
Combine old and new regex to fix GB18030 test discovery crash regression

### DIFF
--- a/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
+++ b/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
@@ -8,8 +8,8 @@ namespace GoogleTestAdapter.TestCases
 
     public class StreamingListTestsParser
     {
-        private static readonly Regex SuiteRegex = new Regex($@"([^.\s]*(?:\.[\S]+)*)(?:{Regex.Escape(GoogleTestConstants.TypedTestMarker)}(.*))?", RegexOptions.Compiled);
-        private static readonly Regex NameRegex = new Regex($@"([\S]*)(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
+        private static readonly Regex SuiteRegex = new Regex($@"(([^.\s]*(?:\.[\S]+)*)|([\w\/]*(?:\.[\w\/]+)*))(?:{Regex.Escape(GoogleTestConstants.TypedTestMarker)}(.*))?", RegexOptions.Compiled);
+        private static readonly Regex NameRegex = new Regex($@"(([\S]*)|([\w\/]*))(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
         private static readonly Regex IsParamRegex = new Regex(@"(\w+/)?\w+/\d+", RegexOptions.Compiled);
 
         private readonly string _testNameSeparator;


### PR DESCRIPTION
Previous regression caused by this PR: https://github.com/microsoft/TestAdapterForGoogleTest/pull/208/files
This regression caused discovery to crash for test cases that contain a GB18030 character.
Still requires a Windows system setting to be enabled for full GB18030 support (discovery/execution), but at least this fix will cause discovery not to crash.
More details attached to actual bug itself: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2033757

This will be for version 1.17.0.38 of TAfGT