### PR TITLE
Missing check against VSTEST.CONSOLE.ARM64.EXE

### DIFF
--- a/GoogleTestAdapter/TestAdapter/Framework/VsVersion.cs
+++ b/GoogleTestAdapter/TestAdapter/Framework/VsVersion.cs
@@ -103,7 +103,7 @@ namespace GoogleTestAdapter.TestAdapter.Framework
         {
             var process = Process.GetCurrentProcess();
             string executable = Path.GetFileName(process.MainModule.FileName).Trim().ToUpperInvariant();
-            while (executable != null && executable != "DEVENV.EXE" && executable != "VSTEST.CONSOLE.EXE")
+            while (executable != null && executable != "DEVENV.EXE" && executable != "VSTEST.CONSOLE.EXE" && executable != "VSTEST.CONSOLE.ARM64.EXE")
             {
                 process = ParentProcessUtils.GetParentProcess(process.Id);
                 executable = process != null


### PR DESCRIPTION
MSTEST on Arm64 machines uses a different process name. 
It includes Am64 as part of the name so we need to also check against VSTEST.CONSOLE.ARM64.EXE