### PR TITLE
Remove ARM32 support due to new windows sdk no longer supports arm32

### DIFF
--- a/GoogleTestAdapter/DiaResolver/DiaResolver.csproj
+++ b/GoogleTestAdapter/DiaResolver/DiaResolver.csproj
@@ -98,9 +98,6 @@
     <Content Include="arm64\msdia140.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="arm\msdia140.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx">

--- a/GoogleTestNuGet/Build.ps1
+++ b/GoogleTestNuGet/Build.ps1
@@ -235,7 +235,6 @@ function Build-NuGet {
         [String]$BuildDir32,
         [String]$BuildDir64,
         [String]$BuildDirARM64,
-        [String]$BuildDirARM,
         [String]$ToolsetName,
         [String]$BuildToolset,
         [Boolean]$DynamicLibraryLinkage,
@@ -284,7 +283,6 @@ function Build-NuGet {
 
     $BuildToDestinationPath = @()
     $BuildToDestinationPath += ,@($BuildDirARM64, "$Dir\$PathToBinaries\arm64")
-    $BuildToDestinationPath += ,@($BuildDirARM, "$Dir\$PathToBinaries\arm")
     $BuildToDestinationPath += ,@($BuildDir32, "$Dir\$PathToBinaries\x86")
 
     # Build x64 last to ensure that the supported x64 binaries are copied to the drop folder for scanning.
@@ -355,9 +353,7 @@ function Build-BinariesAndNuGet {
         -DynamicCRTLinkage $DynamicCRTLinkage
     $BuildDirARM64 = Build-Binaries -ToolsetName $ToolsetName -BuildToolset $BuildToolset -Platform "arm64"   -DynamicLibraryLinkage $DynamicLibraryLinkage `
         -DynamicCRTLinkage $DynamicCRTLinkage
-    $BuildDirARM = Build-Binaries -ToolsetName $ToolsetName -BuildToolset $BuildToolset -Platform "arm"   -DynamicLibraryLinkage $DynamicLibraryLinkage `
-        -DynamicCRTLinkage $DynamicCRTLinkage
-    Build-NuGet -BuildDir32 $BuildDir32 -BuildDir64 $BuildDir64 -BuildDirARM64 $BuildDirARM64 -BuildDirARM $BuildDirARM -ToolsetName $ToolsetName `
+    Build-NuGet -BuildDir32 $BuildDir32 -BuildDir64 $BuildDir64 -BuildDirARM64 $BuildDirARM64 -ToolsetName $ToolsetName `
         -BuildToolset $BuildToolset -DynamicLibraryLinkage $DynamicLibraryLinkage -DynamicCRTLinkage $DynamicCRTLinkage -OutputDir $OutputDir | Out-Null
 }
 

--- a/TestAdapterforGoogle.TestDev17.yml
+++ b/TestAdapterforGoogle.TestDev17.yml
@@ -288,11 +288,6 @@ extends:
             command: custom
             arguments: install VS.Redist.Vctools.Amd64 -Version $(DiaNugetVersion) -OutputDirectory vctools -ExcludeVersion -Source https://pkgs.dev.azure.com/devdiv/_packaging/VS-CoreXtFeeds/nuget/v3/index.json -NoCache -DirectDownload -Verbosity Detailed -NonInteractive
         - task: NuGetCommand@2
-          displayName: NuGet install dia arm
-          inputs:
-            command: custom
-            arguments: install VS.Redist.Vctools.Arm -Version $(DiaNugetVersion) -OutputDirectory vctools -ExcludeVersion -Source https://pkgs.dev.azure.com/devdiv/_packaging/VS-CoreXtFeeds/nuget/v3/index.json -NoCache -DirectDownload -Verbosity Detailed -NonInteractive
-        - task: NuGetCommand@2
           displayName: NuGet install dia arm64
           inputs:
             command: custom
@@ -309,7 +304,6 @@ extends:
             script: |-
               .\compile_typelib.ps1
               Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.Amd64\msdia140.dll' -Destination '..\x64\msdia140.dll' -verbose
-              Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.Arm\msdia140.dll' -Destination '..\arm\msdia140.dll' -verbose
               Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.Arm64\msdia140.dll' -Destination '..\arm64\msdia140.dll' -verbose
               Copy-Item -path '$(Build.Repository.LocalPath)\vctools\VS.Redist.Vctools.X86Files\msdia140.dll' -Destination '..\x86\msdia140.dll' -verbose
             workingDirectory: GoogleTestAdapter/DiaResolver/dia2


### PR DESCRIPTION
We will no longer ship the msdia140.dll for ARM32 or build the google test nuget packages in ARM32 in our pipeline.

[Update app architecture from Arm32 to Arm64 | Microsoft Learn](https://learn.microsoft.com/en-us/windows/arm/arm32-to-arm64)

Windows devices running on an Arm processor
(for example, Snapdragon processors from Qualcomm)
will no longer support AArch32 (Arm32). This change impacts Universal Windows Platform apps that presently target AArch32 (Arm32).
[Support for 32-bit Arm versions of applications will be removed in a future release of Windows 11.](https://www.microsoft.com/windows/windows-11-specifications#table3)
. System binaries for ARM32 support (present in the
sysarm32
folder) will also be removed. After this change, for the small number of applications affected, app features might be different and you might notice a difference in performance. Therefore, we recommend updating your targeted platforms to AArch64 (Arm64), which is supported on all Windows on Arm devices, as soon as possible in order to ensure your customers can continue to enjoy the best possible experience. Follow the guidance on this page to update your applications to AArch64 (Arm64).

