### PR TITLE
Revert "Combine old and new regex to fix GB18030 test discovery crash regression"

### DIFF
--- a/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
+++ b/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
@@ -8,8 +8,8 @@ namespace GoogleTestAdapter.TestCases
 
     public class StreamingListTestsParser
     {
-        private static readonly Regex SuiteRegex = new Regex($@"(([^.\s]*(?:\.[\S]+)*)|([\w\/]*(?:\.[\w\/]+)*))(?:{Regex.Escape(GoogleTestConstants.TypedTestMarker)}(.*))?", RegexOptions.Compiled);
-        private static readonly Regex NameRegex = new Regex($@"(([\S]*)|([\w\/]*))(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
+        private static readonly Regex SuiteRegex = new Regex($@"([^.\s]*(?:\.[\S]+)*)(?:{Regex.Escape(GoogleTestConstants.TypedTestMarker)}(.*))?", RegexOptions.Compiled);
+        private static readonly Regex NameRegex = new Regex($@"([\S]*)(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
         private static readonly Regex IsParamRegex = new Regex(@"(\w+/)?\w+/\d+", RegexOptions.Compiled);
 
         private readonly string _testNameSeparator;


### PR DESCRIPTION
Reverts microsoft/TestAdapterForGoogleTest#280
There was false verification for this PR. It did not end up fixing our GB18030 regression, but it did cause a different regression. So, reverting now.