### PR TITLE
Display Error Messages in UTF8

### DIFF
--- a/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
@@ -400,7 +400,7 @@ namespace GoogleTestAdapter.TestResults
             var testCases = new GoogleTestDiscoverer(MockLogger.Object, MockOptions.Object, new DefaultDiaResolverFactory())
                 .GetTestsFromExecutable(TestResources.Tests_ReleaseX64);
 
-            var parser = new StreamingStandardOutputTestResultParser(testCases, MockLogger.Object, MockFrameworkReporter.Object);
+            var parser = new StreamingStandardOutputTestResultParser(testCases, MockLogger.Object, MockFrameworkReporter.Object, String.Empty);
             CompleteStandardOutput.ForEach(parser.ReportLine);
             parser.Flush();
 
@@ -420,7 +420,7 @@ namespace GoogleTestAdapter.TestResults
                     @"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp")
             };
 
-            var parser = new StreamingStandardOutputTestResultParser(cases, MockLogger.Object, MockFrameworkReporter.Object);
+            var parser = new StreamingStandardOutputTestResultParser(cases, MockLogger.Object, MockFrameworkReporter.Object, String.Empty);
             consoleOutput.ForEach(parser.ReportLine);
             parser.Flush();
 

--- a/GoogleTestAdapter/Core/GoogleTestConstants.cs
+++ b/GoogleTestAdapter/Core/GoogleTestConstants.cs
@@ -18,6 +18,8 @@ namespace GoogleTestAdapter
         public const string NrOfRepetitionsOption = " --gtest_repeat";
         public const string CatchExceptions = " --gtest_catch_exceptions";
         public const string BreakOnFailure = " --gtest_break_on_failure";
+        public const string PrintUTF8 = " --gtest_print_utf8=1";
+        public const string XMLOutput = " --gtest_output=xml:XMLGoogleTestResults.xml";
 
         public const int ShuffleTestsSeedDefaultValue = 0;
         public const string ShuffleTestsSeedMaxValueAsString = "99999";

--- a/GoogleTestAdapter/Core/Runners/CommandLineGenerator.cs
+++ b/GoogleTestAdapter/Core/Runners/CommandLineGenerator.cs
@@ -47,6 +47,10 @@ namespace GoogleTestAdapter.Runners
         public IEnumerable<Args> GetCommandLines()
         {
             string baseCommandLine = string.Empty;
+
+            // Also generates the google test results in XML format for when we need to parse the error messages to support UTF8.
+            baseCommandLine += GoogleTestConstants.XMLOutput;
+
             baseCommandLine += GetCatchExceptionsParameter();
             baseCommandLine += GetBreakOnFailureParameter();
             baseCommandLine += GetAlsoRunDisabledTestsParameter();

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -141,7 +141,8 @@ namespace GoogleTestAdapter.Runners
                 {
                     break;
                 }
-                var streamingParser = new StreamingStandardOutputTestResultParser(arguments.TestCases, _logger, _frameworkReporter);
+
+                var streamingParser = new StreamingStandardOutputTestResultParser(arguments.TestCases, _logger, _frameworkReporter, executable);
                 var results = RunTests(executable, workingDir, envVars, isBeingDebugged, debuggedLauncher, arguments, executor, streamingParser).ToArray();
 
                 try

--- a/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
@@ -1,6 +1,7 @@
 ﻿// This file has been modified by Microsoft on 9/2017.
 
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -17,12 +18,16 @@ namespace GoogleTestAdapter.TestResults
 
         public TestCase CrashedTestCase { get; private set; }
         public IList<TestResult> TestResults { get; } = new List<TestResult>();
+        public List<TestResult> XmlTestResults { get; set; } = new List<TestResult>();
 
+        // Used so that we only get the XML results once per test run.
+        private bool doXMLResultsExist = false;
         private readonly List<TestCase> _testCasesRun;
         private readonly ILogger _logger;
         private readonly ITestFrameworkReporter _reporter;
 
         private readonly List<string> _consoleOutput = new List<string>();
+        private readonly string _executable;
 
         static StreamingStandardOutputTestResultParser()
         {
@@ -32,11 +37,21 @@ namespace GoogleTestAdapter.TestResults
         }
 
         public StreamingStandardOutputTestResultParser(IEnumerable<TestCase> testCasesRun,
-                ILogger logger, ITestFrameworkReporter reporter)
+                ILogger logger, ITestFrameworkReporter reporter, string executable)
         {
             _testCasesRun = testCasesRun.ToList();
             _logger = logger;
             _reporter = reporter;
+            _executable = executable;
+        }
+
+        public List<TestResult> GetXMLResults(IEnumerable<TestCase> testCasesRun)
+        {
+            // Parse in XML so we can get the error message and stack trace in UTF8 since console output does not support this by default.
+            string xmlResultFilePath = Path.Combine(Path.GetDirectoryName(_executable), "XMLGoogleTestResults.xml");
+            var xmlParser = new XmlTestResultParser(testCasesRun, xmlResultFilePath, _logger);
+            var xmlTestResults = xmlParser.GetTestResults();
+            return xmlTestResults;
         }
 
         public void ReportLine(string line)
@@ -141,13 +156,42 @@ namespace GoogleTestAdapter.TestResults
             }
             if (StandardOutputTestResultParser.IsFailedLine(line))
             {
-                ErrorMessageParser parser = new ErrorMessageParser(errorMsg);
-                parser.Parse();
+                string testResultErrorMessage = String.Empty;
+                string testResultErrorStackTrace = String.Empty;
+                string xmlErrorMessage = String.Empty;
+                string xmlErrorStackTrace = String.Empty;
+
+                // Map and extract error messages from xml parser to inject into this test failed result. This allows support for UTF8 error messages. Bug 1951549.
+                //  Console output does not always support UTF8 output by default, but XML results do.
+                if (!doXMLResultsExist)
+                {
+                    XmlTestResults = GetXMLResults(_testCasesRun.AsEnumerable());
+                    doXMLResultsExist = true;
+                }
+
+                foreach (var xmlTestResult in XmlTestResults)
+                {
+                    if (xmlTestResult.TestCase.FullyQualifiedNameWithNamespace == testCase.FullyQualifiedNameWithNamespace)
+                    {
+                        testResultErrorMessage = xmlTestResult.ErrorMessage;
+                        testResultErrorStackTrace = xmlTestResult.ErrorStackTrace;
+                    }
+                }
+
+                // If we did not find the error message or stack trace in the XML parser, then parse the error message from the console output.
+                if (testResultErrorMessage == String.Empty || testResultErrorStackTrace == String.Empty)
+                {
+                    ErrorMessageParser parser = new ErrorMessageParser(errorMsg);
+                    parser.Parse();
+                    testResultErrorMessage = parser.ErrorMessage;
+                    testResultErrorStackTrace = parser.ErrorStackTrace;
+                }
+
                 return StandardOutputTestResultParser.CreateFailedTestResult(
                     testCase,
                     StandardOutputTestResultParser.ParseDuration(line, _logger),
-                    parser.ErrorMessage,
-                    parser.ErrorStackTrace);
+                    testResultErrorMessage,
+                    testResultErrorStackTrace);
             }
             if (StandardOutputTestResultParser.IsPassedLine(line))
             {


### PR DESCRIPTION
Console output for google test is not in utf8 by default, but XML is. So, to account for this special case we parse and extract the error messages in UTF8 by using the XML output, and attach them to the TestResult.