### PR TITLE
Update Microsoft.VisualStudio.Shell.15.0 nuget package to latest version available

### DIFF
--- a/GoogleTestAdapter/NewProjectWizard/NewProjectWizard.csproj
+++ b/GoogleTestAdapter/NewProjectWizard/NewProjectWizard.csproj
@@ -62,7 +62,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-2-31221-277" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.8.37221" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.13.40008" />
     <PackageReference Include="Microsoft.VisualStudio.TemplateWizardInterface" Version="17.0.0-preview-1-31216-036" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/GoogleTestAdapter/VsPackage.GTA/VsPackage.GTA.csproj
+++ b/GoogleTestAdapter/VsPackage.GTA/VsPackage.GTA.csproj
@@ -143,7 +143,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.10.0-release-20210330-02" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="17.0.49-g3bcbfd968c" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.8.37221" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.13.40008" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-2-31221-277" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/GoogleTestAdapter/VsPackage.TAfGT/VsPackage.TAfGT.csproj
+++ b/GoogleTestAdapter/VsPackage.TAfGT/VsPackage.TAfGT.csproj
@@ -118,8 +118,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.10.0-release-20210330-02" />
     <PackageReference Include="Microsoft.VisualStudio.TestWindow.Interfaces" Version="11.0.61030" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.8.37221" />
-    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-2-31221-277" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.13.40008" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.13.40008" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
Previous package version was the latest version available in vc-test-adapters feed but not latest version publicly available. Latest version was added to vc-test-adapters so it can be injected in this test adapter.