### PR TITLE
Add support for skipped tests

### DIFF
--- a/GoogleTestAdapter/Core.Tests/TestResults/StandardOutputTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/StandardOutputTestResultParserTests.cs
@@ -102,6 +102,34 @@ namespace GoogleTestAdapter.TestResults
             @"[  PASSED  ] 2 test.",
         };
 
+        /// <summary>
+        /// <see cref="https://github.com/csoltenborn/GoogleTestAdapter/issues/260"/>
+        /// </summary>
+        private string[] ConsoleOutputWithSkippedTest { get; } = @"[==========] Running 3 tests from 1 test suite.
+[----------] Global test environment set-up.
+[----------] 3 tests from Test
+[ RUN      ] Test.Succeed
+[       OK ] Test.Succeed (0 ms)
+[ RUN      ] Test.Skip
+[  SKIPPED ] Test.Skip (1 ms)
+[ RUN      ] Test.Fail
+C:\...\test.cpp(14): error: Value of: false
+  Actual: false
+Expected: true
+[  FAILED  ] Test.Fail (0 ms)
+[----------] 3 tests from Test (3 ms total)
+
+[----------] Global test environment tear-down
+[==========] 3 tests from 1 test suite ran. (6 ms total)
+[  PASSED  ] 1 test.
+[  SKIPPED ] 1 test, listed below:
+[  SKIPPED ] Test.Skip
+[  FAILED  ] 1 test, listed below:
+[  FAILED  ] Test.Fail
+
+ 1 FAILED TEST
+".Split('\n');
+
 
         private List<string> CrashesImmediately { get; set; }
         private List<string> CrashesAfterErrorMsg { get; set; }
@@ -274,6 +302,34 @@ namespace GoogleTestAdapter.TestResults
             XmlTestResultParserTests.AssertTestResultIsPassed(results[0]);
             results[1].TestCase.FullyQualifiedName.Should().Be("Test.A");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[1]);
+        }
+
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void GetTestResults_OutputWithSkippedTest_AllResultsAreFound()
+        {
+            var cases = new List<TestCase>
+            {
+                TestDataCreator.ToTestCase("Test.Succeed", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+                TestDataCreator.ToTestCase("Test.Skip", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+                TestDataCreator.ToTestCase("Test.Fail", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+            };
+
+            var results = new StandardOutputTestResultParser(cases, ConsoleOutputWithSkippedTest, TestEnvironment.Logger).GetTestResults();
+
+            results.Should().HaveCount(3);
+
+            var result = results[0];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Succeed");
+            XmlTestResultParserTests.AssertTestResultIsPassed(result);
+
+            result = results[1];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Skip");
+            XmlTestResultParserTests.AssertTestResultIsSkipped(result);
+
+            result = results[2];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Fail");
+            XmlTestResultParserTests.AssertTestResultIsFailure(result);
         }
 
         [TestMethod]

--- a/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
@@ -341,7 +341,7 @@ Expected: true
                     @"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp")
             };
 
-            var parser = new StreamingStandardOutputTestResultParser(cases, TestEnvironment.Logger, MockFrameworkReporter.Object);
+            var parser = new StreamingStandardOutputTestResultParser(cases, MockLogger.Object, MockFrameworkReporter.Object, String.Empty);
             ConsoleOutputWithPrefixingTest.ToList().ForEach(parser.ReportLine);
             parser.Flush();
             var results = parser.TestResults;
@@ -364,7 +364,7 @@ Expected: true
                 TestDataCreator.ToTestCase("Test.Fail", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
             };
 
-            var parser = new StreamingStandardOutputTestResultParser(cases, TestEnvironment.Logger, MockFrameworkReporter.Object);
+            var parser = new StreamingStandardOutputTestResultParser(cases, MockLogger.Object, MockFrameworkReporter.Object, String.Empty);
             ConsoleOutputWithSkippedTest.ToList().ForEach(parser.ReportLine);
             parser.Flush();
             var results = parser.TestResults;

--- a/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
@@ -114,6 +114,34 @@ namespace GoogleTestAdapter.TestResults
             @"[  PASSED  ] 2 test.",
         };
 
+        /// <summary>
+        /// <see cref="https://github.com/csoltenborn/GoogleTestAdapter/issues/260"/>
+        /// </summary>
+        private string[] ConsoleOutputWithSkippedTest { get; } = @"[==========] Running 3 tests from 1 test suite.
+[----------] Global test environment set-up.
+[----------] 3 tests from Test
+[ RUN      ] Test.Succeed
+[       OK ] Test.Succeed (0 ms)
+[ RUN      ] Test.Skip
+[  SKIPPED ] Test.Skip (1 ms)
+[ RUN      ] Test.Fail
+C:\...\test.cpp(14): error: Value of: false
+  Actual: false
+Expected: true
+[  FAILED  ] Test.Fail (0 ms)
+[----------] 3 tests from Test (3 ms total)
+
+[----------] Global test environment tear-down
+[==========] 3 tests from 1 test suite ran. (6 ms total)
+[  PASSED  ] 1 test.
+[  SKIPPED ] 1 test, listed below:
+[  SKIPPED ] Test.Skip
+[  FAILED  ] 1 test, listed below:
+[  FAILED  ] Test.Fail
+
+ 1 FAILED TEST
+".Split('\n');
+
 
         private List<string> CrashesImmediately { get; set; }
         private List<string> CrashesAfterErrorMsg { get; set; }
@@ -313,14 +341,47 @@ namespace GoogleTestAdapter.TestResults
                     @"c:\users\chris\documents\visual studio 2015\projects\consoleapplication1\consoleapplication1tests\source.cpp")
             };
 
-            var results = new StandardOutputTestResultParser(cases, ConsoleOutputWithPrefixingTest, TestEnvironment.Logger)
-                .GetTestResults();
+            var parser = new StreamingStandardOutputTestResultParser(cases, TestEnvironment.Logger, MockFrameworkReporter.Object);
+            ConsoleOutputWithPrefixingTest.ToList().ForEach(parser.ReportLine);
+            parser.Flush();
+            var results = parser.TestResults;
 
             results.Count.Should().Be(2);
             results[0].TestCase.FullyQualifiedName.Should().Be("Test.AB");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[0]);
             results[1].TestCase.FullyQualifiedName.Should().Be("Test.A");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[1]);
+        }
+
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void GetTestResults_OutputWithSkippedTest_AllResultsAreFound()
+        {
+            var cases = new List<TestCase>
+            {
+                TestDataCreator.ToTestCase("Test.Succeed", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+                TestDataCreator.ToTestCase("Test.Skip", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+                TestDataCreator.ToTestCase("Test.Fail", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+            };
+
+            var parser = new StreamingStandardOutputTestResultParser(cases, TestEnvironment.Logger, MockFrameworkReporter.Object);
+            ConsoleOutputWithSkippedTest.ToList().ForEach(parser.ReportLine);
+            parser.Flush();
+            var results = parser.TestResults;
+
+            results.Should().HaveCount(3);
+
+            var result = results[0];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Succeed");
+            XmlTestResultParserTests.AssertTestResultIsPassed(result);
+
+            result = results[1];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Skip");
+            XmlTestResultParserTests.AssertTestResultIsSkipped(result);
+
+            result = results[2];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Fail");
+            XmlTestResultParserTests.AssertTestResultIsFailure(result);
         }
 
         [TestMethod]

--- a/GoogleTestAdapter/Core.Tests/TestResults/XmlTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/XmlTestResultParserTests.cs
@@ -171,7 +171,7 @@ Something's wrong :(";
             testResult.ErrorMessage.Should().BeNull();
         }
 
-        private void AssertTestResultIsSkipped(Model.TestResult testResult)
+        public static void AssertTestResultIsSkipped(Model.TestResult testResult)
         {
             testResult.Outcome.Should().Be(Model.TestOutcome.Skipped);
             testResult.ErrorMessage.Should().BeNull();

--- a/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
@@ -15,6 +15,7 @@ namespace GoogleTestAdapter.TestResults
         private const string Run = "[ RUN      ]";
         public const string Failed = "[  FAILED  ]";
         public const string Passed = "[       OK ]";
+        public const string Skipped = "[  SKIPPED ]";
         public const string FailedFixture = "SetUpTestSuite or TearDownTestSuite";
 
         public static readonly string CrashText = Resources.CrashText;
@@ -80,7 +81,7 @@ namespace GoogleTestAdapter.TestResults
 
 
             string errorMsg = "";
-            while (!(IsFailedLine(line) || IsPassedLine(line)) && currentLineIndex <= _consoleOutput.Count)
+            while (!(IsFailedLine(line) || IsPassedLine(line) || IsSkippedLine(line)) && currentLineIndex <= _consoleOutput.Count)
             {
                 errorMsg += line + "\n";
                 line = currentLineIndex < _consoleOutput.Count ? _consoleOutput[currentLineIndex] : "";
@@ -96,6 +97,10 @@ namespace GoogleTestAdapter.TestResults
             if (IsPassedLine(line))
             {
                 return CreatePassedTestResult(testCase, ParseDuration(line));
+            }
+            if (IsSkippedLine(line))
+            {
+                return CreateSkippedTestResult(testCase, ParseDuration(line));
             }
 
             CrashedTestCase = testCase;
@@ -163,6 +168,17 @@ namespace GoogleTestAdapter.TestResults
             };
         }
 
+        public static TestResult CreateSkippedTestResult(TestCase testCase, TimeSpan duration)
+        {
+            return new TestResult(testCase)
+            {
+                ComputerName = Environment.MachineName,
+                DisplayName = testCase.DisplayName,
+                Outcome = TestOutcome.Skipped,
+                Duration = duration
+            };
+        }
+
         public static TestResult CreateFailedTestResult(TestCase testCase, TimeSpan duration, string errorMessage, string errorStackTrace)
         {
             return new TestResult(testCase)
@@ -213,6 +229,11 @@ namespace GoogleTestAdapter.TestResults
         public static bool IsFailedLine(string line)
         {
             return line.StartsWith(Failed, StringComparison.Ordinal);
+        }
+
+        public static bool IsSkippedLine(string line)
+        {
+            return line.StartsWith(Skipped);
         }
 
         public static string RemovePrefix(string line)

--- a/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
@@ -177,7 +177,8 @@ namespace GoogleTestAdapter.TestResults
             string errorMsg = "";
             while (
                 !(StandardOutputTestResultParser.IsFailedLine(line)
-                    || StandardOutputTestResultParser.IsPassedLine(line))
+                    || StandardOutputTestResultParser.IsPassedLine(line)
+                    || StandardOutputTestResultParser.IsSkippedLine(line))
                 && currentLineIndex <= _consoleOutput.Count)
             {
                 errorMsg += line + "\n";
@@ -226,6 +227,12 @@ namespace GoogleTestAdapter.TestResults
             if (StandardOutputTestResultParser.IsPassedLine(line))
             {
                 return StandardOutputTestResultParser.CreatePassedTestResult(
+                    testCase,
+                    StandardOutputTestResultParser.ParseDuration(line, _logger));
+            }
+            if (StandardOutputTestResultParser.IsSkippedLine(line))
+            {
+                return StandardOutputTestResultParser.CreateSkippedTestResult(
                     testCase,
                     StandardOutputTestResultParser.ParseDuration(line, _logger));
             }


### PR DESCRIPTION
I've cherry-picked the commit from the GTA project (https://github.com/csoltenborn/GoogleTestAdapter/pull/262) -- without other unrelated changes, and made minor changes to make it work in this fork. 

I couldn't get a fully working setup (or did not understand how to properly run all tests), so I'd suggest to maintainers to take a look :) Otherwise, my team started used it (as a replacement of the official extension) and so far, no issues. 

I'll report back if anything is raised.