### PR TITLE
Add support for new v145 toolset

### DIFF
--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vcxproj
@@ -24,7 +24,7 @@
     <Keyword>Win32Proj</Keyword>
     <WindowsTargetPlatformVersion>$targetplatformversion$</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$platformtoolset$</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/GoogleTestNuGet/googletest.targets.tt
+++ b/GoogleTestNuGet/googletest.targets.tt
@@ -5,7 +5,7 @@
 <#@ parameter type="System.String" name="PathToBinaries" #>
 <#@ parameter type="System.String" name="ConfigurationType" #>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(Force-Enable-<#= PackageNameDashes #>)' == '' And (('$(PlatformToolset)' != 'v143' And '$(PlatformToolset)' != 'v142' And '$(PlatformToolset)' != 'v141' And '$(PlatformToolset)' != 'v140') Or '$(ApplicationType)' != '')">
+  <PropertyGroup Condition="'$(Force-Enable-<#= PackageNameDashes #>)' == '' And (('$(PlatformToolset)' != 'v145' AND '$(PlatformToolset)' != 'v143' And '$(PlatformToolset)' != 'v142' And '$(PlatformToolset)' != 'v141' And '$(PlatformToolset)' != 'v140') Or '$(ApplicationType)' != '')">
     <Disable-<#= PackageNameDashes #>>true</Disable-<#= PackageNameDashes #>>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Force-Disable-<#= PackageNameDashes #>)' != ''">


### PR DESCRIPTION
Update targets to support new v145 toolset and use platformtoolset variable to always support newest toolset versions.