### PR TITLE
Fix NewProjectWizard load and update dependencies to latest versions

### DIFF
--- a/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vstemplate
+++ b/GoogleTestAdapter/GoogleTestProjectTemplate/GoogleTest.vstemplate
@@ -21,7 +21,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>NewProjectWizard, Version=0.1.0.0, Culture=neutral, PublicKeyToken=1924acebdd4c8a75</Assembly>
+    <Assembly>NewProjectWizard, Version=0.1.0.0, Culture=neutral, PublicKeyToken=028d073f99e04687</Assembly>
     <FullClassName>Microsoft.NewProjectWizard.WizardImplementation</FullClassName>
   </WizardExtension>
   <WizardData>

--- a/GoogleTestAdapter/NewProjectWizard/NewProjectWizard.csproj
+++ b/GoogleTestAdapter/NewProjectWizard/NewProjectWizard.csproj
@@ -134,4 +134,13 @@
       </FilesToSign>
     </ItemGroup>
   </Target>
+  <PropertyGroup>
+    <PreBuildEvent Condition="'$(RealSign)' != 'True'">if exist "$(SolutionDir)Keys\Key_Release.snk" (
+    echo Using Release key for signing assembly
+    copy "$(SolutionDir)Keys\Key_Release.snk" "$(ProjectDir)Key.snk"
+) else (
+    echo Using Debug key for signing assembly
+    copy "$(SolutionDir)Keys\Key_Debug.snk" "$(ProjectDir)Key.snk"
+)</PreBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/GoogleTestAdapter/NewProjectWizard/NewProjectWizard.csproj
+++ b/GoogleTestAdapter/NewProjectWizard/NewProjectWizard.csproj
@@ -60,10 +60,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-2-31221-277" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" Version="17.13.40008" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.13.40008" />
-    <PackageReference Include="Microsoft.VisualStudio.TemplateWizardInterface" Version="17.0.0-preview-1-31216-036" />
+    <PackageReference Include="Microsoft.VisualStudio.TemplateWizardInterface" Version="17.6.36308" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/pipeline/common.yml
+++ b/pipeline/common.yml
@@ -166,15 +166,6 @@ jobs:
             $_
           }
         } | Set-Content $build_script
-  - task: PowerShell@2
-    displayName: Update token for template
-    inputs:
-      targetType: inline
-      script: |-
-        $project_template = 'GoogleTestAdapter\GoogleTestProjectTemplate\GoogleTest.vstemplate'
-        (Get-Content $project_template) | ForEach-Object {
-          $_ -Replace "1924acebdd4c8a75", "b03f5f7f11d50a3a"
-        } | Set-Content $project_template
   - task: CopyFiles@2
     displayName: 'Copy FinalPublicKey.snk to TestAdapterForGoogleTest'
     inputs:


### PR DESCRIPTION
Latest TAfGT version to fail to load the NewProjectWizard.dll assembly.