### PR TITLE
Show stdout content in the Test Explorer test detail summary

### DIFF
--- a/GoogleTestAdapter/Core/Model/TestResult.cs
+++ b/GoogleTestAdapter/Core/Model/TestResult.cs
@@ -17,7 +17,6 @@ namespace GoogleTestAdapter.Model
         public TimeSpan Duration { get; set; }
 
         public string StandardOutput { get; set; }
-        public string StandardError { get; set; }
 
         public TestResult(TestCase testCase)
         {

--- a/GoogleTestAdapter/Core/Model/TestResult.cs
+++ b/GoogleTestAdapter/Core/Model/TestResult.cs
@@ -16,6 +16,9 @@ namespace GoogleTestAdapter.Model
         public string ErrorStackTrace { get; set; }
         public TimeSpan Duration { get; set; }
 
+        public string StandardOutput { get; set; }
+        public string StandardError { get; set; }
+
         public TestResult(TestCase testCase)
         {
             TestCase = testCase;

--- a/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
@@ -92,17 +92,17 @@ namespace GoogleTestAdapter.TestResults
             {
                 ErrorMessageParser parser = new ErrorMessageParser(consoleOutput);
                 parser.Parse();
-                return CreateFailedTestResult(testCase, ParseDuration(line), parser.ErrorMessage, parser.ErrorStackTrace, consoleOutput.TrimEnd('\n'));
+                return CreateFailedTestResult(testCase, ParseDuration(line), parser.ErrorMessage, parser.ErrorStackTrace, consoleOutput);
             }
             if (IsPassedLine(line))
             {
-                return CreatePassedTestResult(testCase, ParseDuration(line), consoleOutput.TrimEnd('\n'));
+                return CreatePassedTestResult(testCase, ParseDuration(line), consoleOutput);
             }
 
             CrashedTestCase = testCase;
             string message = CrashText;
             message += consoleOutput == "" ? "" : "\nTest output:\n\n" + consoleOutput;
-            return CreateFailedTestResult(testCase, TimeSpan.FromMilliseconds(0), message, "", consoleOutput.TrimEnd('\n'));
+            return CreateFailedTestResult(testCase, TimeSpan.FromMilliseconds(0), message, "", consoleOutput);
         }
 
         private void SplitLineIfNecessary(ref string line, int currentLineIndex)
@@ -161,7 +161,7 @@ namespace GoogleTestAdapter.TestResults
                 DisplayName = testCase.DisplayName,
                 Outcome = TestOutcome.Passed,
                 Duration = duration,
-                StandardOutput = standardOutput
+                StandardOutput = standardOutput.TrimEnd('\n')
             };
         }
 
@@ -175,7 +175,7 @@ namespace GoogleTestAdapter.TestResults
                 ErrorMessage = errorMessage,
                 ErrorStackTrace = errorStackTrace,
                 Duration = duration,
-                StandardOutput = standardOutput
+                StandardOutput = standardOutput.TrimEnd('\n')
             };
         }
 

--- a/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
@@ -71,7 +71,7 @@ namespace GoogleTestAdapter.TestResults
             if (currentLineIndex >= _consoleOutput.Count)
             {
                 CrashedTestCase = testCase;
-                return CreateFailedTestResult(testCase, TimeSpan.FromMilliseconds(0), CrashText, "");
+                return CreateFailedTestResult(testCase, TimeSpan.FromMilliseconds(0), CrashText, "", "");
             }
 
             line = _consoleOutput[currentLineIndex];
@@ -80,9 +80,12 @@ namespace GoogleTestAdapter.TestResults
 
 
             string errorMsg = "";
+            string testOutput = "";
             while (!(IsFailedLine(line) || IsPassedLine(line)) && currentLineIndex <= _consoleOutput.Count)
             {
                 errorMsg += line + "\n";
+                // Capture all output as standard output (could be enhanced to separate stdout/stderr)
+                testOutput += line + "\n";
                 line = currentLineIndex < _consoleOutput.Count ? _consoleOutput[currentLineIndex] : "";
                 SplitLineIfNecessary(ref line, currentLineIndex);
                 currentLineIndex++;
@@ -91,17 +94,17 @@ namespace GoogleTestAdapter.TestResults
             {
                 ErrorMessageParser parser = new ErrorMessageParser(errorMsg);
                 parser.Parse();
-                return CreateFailedTestResult(testCase, ParseDuration(line), parser.ErrorMessage, parser.ErrorStackTrace);
+                return CreateFailedTestResult(testCase, ParseDuration(line), parser.ErrorMessage, parser.ErrorStackTrace, testOutput.TrimEnd('\n'));
             }
             if (IsPassedLine(line))
             {
-                return CreatePassedTestResult(testCase, ParseDuration(line));
+                return CreatePassedTestResult(testCase, ParseDuration(line), testOutput.TrimEnd('\n'));
             }
 
             CrashedTestCase = testCase;
             string message = CrashText;
             message += errorMsg == "" ? "" : "\nTest output:\n\n" + errorMsg;
-            return CreateFailedTestResult(testCase, TimeSpan.FromMilliseconds(0), message, "");
+            return CreateFailedTestResult(testCase, TimeSpan.FromMilliseconds(0), message, "", testOutput.TrimEnd('\n'));
         }
 
         private void SplitLineIfNecessary(ref string line, int currentLineIndex)
@@ -152,18 +155,19 @@ namespace GoogleTestAdapter.TestResults
                 : duration;
         }
 
-        public static TestResult CreatePassedTestResult(TestCase testCase, TimeSpan duration)
+        public static TestResult CreatePassedTestResult(TestCase testCase, TimeSpan duration, string standardOutput = "")
         {
             return new TestResult(testCase)
             {
                 ComputerName = Environment.MachineName,
                 DisplayName = testCase.DisplayName,
                 Outcome = TestOutcome.Passed,
-                Duration = duration
+                Duration = duration,
+                StandardOutput = standardOutput
             };
         }
 
-        public static TestResult CreateFailedTestResult(TestCase testCase, TimeSpan duration, string errorMessage, string errorStackTrace)
+        public static TestResult CreateFailedTestResult(TestCase testCase, TimeSpan duration, string errorMessage, string errorStackTrace, string standardOutput = "")
         {
             return new TestResult(testCase)
             {
@@ -172,7 +176,8 @@ namespace GoogleTestAdapter.TestResults
                 Outcome = TestOutcome.Failed,
                 ErrorMessage = errorMessage,
                 ErrorStackTrace = errorStackTrace,
-                Duration = duration
+                Duration = duration,
+                StandardOutput = standardOutput
             };
         }
 

--- a/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
@@ -78,33 +78,31 @@ namespace GoogleTestAdapter.TestResults
             SplitLineIfNecessary(ref line, currentLineIndex);
             currentLineIndex++;
 
-
-            string errorMsg = "";
-            string testOutput = "";
+            // Capture all output and treat it as standard output for the test explorer. If we wanted to distinguish between stdout and stderr, we have
+            // to change the way we capture the output in ProcessLauncher and ProcessExecutor since they merge the two streams.
+            string consoleOutput = "";
             while (!(IsFailedLine(line) || IsPassedLine(line)) && currentLineIndex <= _consoleOutput.Count)
             {
-                errorMsg += line + "\n";
-                // Capture all output as standard output (could be enhanced to separate stdout/stderr)
-                testOutput += line + "\n";
+                consoleOutput += line + "\n";
                 line = currentLineIndex < _consoleOutput.Count ? _consoleOutput[currentLineIndex] : "";
                 SplitLineIfNecessary(ref line, currentLineIndex);
                 currentLineIndex++;
             }
             if (IsFailedLine(line))
             {
-                ErrorMessageParser parser = new ErrorMessageParser(errorMsg);
+                ErrorMessageParser parser = new ErrorMessageParser(consoleOutput);
                 parser.Parse();
-                return CreateFailedTestResult(testCase, ParseDuration(line), parser.ErrorMessage, parser.ErrorStackTrace, testOutput.TrimEnd('\n'));
+                return CreateFailedTestResult(testCase, ParseDuration(line), parser.ErrorMessage, parser.ErrorStackTrace, consoleOutput.TrimEnd('\n'));
             }
             if (IsPassedLine(line))
             {
-                return CreatePassedTestResult(testCase, ParseDuration(line), testOutput.TrimEnd('\n'));
+                return CreatePassedTestResult(testCase, ParseDuration(line), consoleOutput.TrimEnd('\n'));
             }
 
             CrashedTestCase = testCase;
             string message = CrashText;
-            message += errorMsg == "" ? "" : "\nTest output:\n\n" + errorMsg;
-            return CreateFailedTestResult(testCase, TimeSpan.FromMilliseconds(0), message, "", testOutput.TrimEnd('\n'));
+            message += consoleOutput == "" ? "" : "\nTest output:\n\n" + consoleOutput;
+            return CreateFailedTestResult(testCase, TimeSpan.FromMilliseconds(0), message, "", consoleOutput.TrimEnd('\n'));
         }
 
         private void SplitLineIfNecessary(ref string line, int currentLineIndex)

--- a/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
@@ -133,7 +133,7 @@ namespace GoogleTestAdapter.TestResults
                 TestCase testCase = StandardOutputTestResultParser.FindTestcase(qualifiedTestName, _testCasesRun);
                 if(testCase != null)
                 {
-                    TestResult result = StandardOutputTestResultParser.CreateFailedTestResult(testCase, TimeSpan.FromMilliseconds(0),"","");
+                    TestResult result = StandardOutputTestResultParser.CreateFailedTestResult(testCase, TimeSpan.FromMilliseconds(0), "", "", "");
                     if (result != null)
                     {
                         _reporter.ReportTestResults(result.Yield());
@@ -169,18 +169,22 @@ namespace GoogleTestAdapter.TestResults
                     testCase,
                     TimeSpan.FromMilliseconds(0),
                     StandardOutputTestResultParser.CrashText,
+                    "",
                     "");
             }
 
             line = _consoleOutput[currentLineIndex++];
 
             string errorMsg = "";
+            string testOutput = "";
             while (
                 !(StandardOutputTestResultParser.IsFailedLine(line)
                     || StandardOutputTestResultParser.IsPassedLine(line))
                 && currentLineIndex <= _consoleOutput.Count)
             {
                 errorMsg += line + "\n";
+                // Capture all output as standard output
+                testOutput += line + "\n";
                 line = currentLineIndex < _consoleOutput.Count ? _consoleOutput[currentLineIndex] : "";
                 currentLineIndex++;
             }
@@ -221,13 +225,15 @@ namespace GoogleTestAdapter.TestResults
                     testCase,
                     StandardOutputTestResultParser.ParseDuration(line, _logger),
                     testResultErrorMessage,
-                    testResultErrorStackTrace);
+                    testResultErrorStackTrace,
+                    testOutput.TrimEnd('\n'));
             }
             if (StandardOutputTestResultParser.IsPassedLine(line))
             {
                 return StandardOutputTestResultParser.CreatePassedTestResult(
                     testCase,
-                    StandardOutputTestResultParser.ParseDuration(line, _logger));
+                    StandardOutputTestResultParser.ParseDuration(line, _logger),
+                    testOutput.TrimEnd('\n'));
             }
 
             CrashedTestCase = testCase;
@@ -237,7 +243,8 @@ namespace GoogleTestAdapter.TestResults
                 testCase,
                 TimeSpan.FromMilliseconds(0),
                 message,
-                "");
+                "",
+                testOutput.TrimEnd('\n'));
             return result;
         }
 

--- a/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
@@ -175,16 +175,15 @@ namespace GoogleTestAdapter.TestResults
 
             line = _consoleOutput[currentLineIndex++];
 
-            string errorMsg = "";
-            string testOutput = "";
+            // Capture all output and treat it as standard output for the test explorer. If we wanted to distinguish between stdout and stderr, we have
+            // to change the way we capture the output in ProcessLauncher and ProcessExecutor since they merge the two streams.
+            string consoleOutput = "";
             while (
                 !(StandardOutputTestResultParser.IsFailedLine(line)
                     || StandardOutputTestResultParser.IsPassedLine(line))
                 && currentLineIndex <= _consoleOutput.Count)
             {
-                errorMsg += line + "\n";
-                // Capture all output as standard output
-                testOutput += line + "\n";
+                consoleOutput += line + "\n";
                 line = currentLineIndex < _consoleOutput.Count ? _consoleOutput[currentLineIndex] : "";
                 currentLineIndex++;
             }
@@ -215,7 +214,7 @@ namespace GoogleTestAdapter.TestResults
                 // If we did not find the error message or stack trace in the XML parser, then parse the error message from the console output.
                 if (testResultErrorMessage == String.Empty || testResultErrorStackTrace == String.Empty)
                 {
-                    ErrorMessageParser parser = new ErrorMessageParser(errorMsg);
+                    ErrorMessageParser parser = new ErrorMessageParser(consoleOutput);
                     parser.Parse();
                     testResultErrorMessage = parser.ErrorMessage;
                     testResultErrorStackTrace = parser.ErrorStackTrace;
@@ -226,25 +225,25 @@ namespace GoogleTestAdapter.TestResults
                     StandardOutputTestResultParser.ParseDuration(line, _logger),
                     testResultErrorMessage,
                     testResultErrorStackTrace,
-                    testOutput.TrimEnd('\n'));
+                    consoleOutput.TrimEnd('\n'));
             }
             if (StandardOutputTestResultParser.IsPassedLine(line))
             {
                 return StandardOutputTestResultParser.CreatePassedTestResult(
                     testCase,
                     StandardOutputTestResultParser.ParseDuration(line, _logger),
-                    testOutput.TrimEnd('\n'));
+                    consoleOutput.TrimEnd('\n'));
             }
 
             CrashedTestCase = testCase;
             string message = StandardOutputTestResultParser.CrashText;
-            message += errorMsg == "" ? "" : ("\n" + Resources.TestOutput + $"\n\n{errorMsg}");
+            message += consoleOutput == "" ? "" : ("\n" + Resources.TestOutput + $"\n\n{consoleOutput}");
             TestResult result = StandardOutputTestResultParser.CreateFailedTestResult(
                 testCase,
                 TimeSpan.FromMilliseconds(0),
                 message,
                 "",
-                testOutput.TrimEnd('\n'));
+                consoleOutput.TrimEnd('\n'));
             return result;
         }
 

--- a/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
@@ -225,14 +225,14 @@ namespace GoogleTestAdapter.TestResults
                     StandardOutputTestResultParser.ParseDuration(line, _logger),
                     testResultErrorMessage,
                     testResultErrorStackTrace,
-                    consoleOutput.TrimEnd('\n'));
+                    consoleOutput);
             }
             if (StandardOutputTestResultParser.IsPassedLine(line))
             {
                 return StandardOutputTestResultParser.CreatePassedTestResult(
                     testCase,
                     StandardOutputTestResultParser.ParseDuration(line, _logger),
-                    consoleOutput.TrimEnd('\n'));
+                    consoleOutput);
             }
 
             CrashedTestCase = testCase;
@@ -243,7 +243,7 @@ namespace GoogleTestAdapter.TestResults
                 TimeSpan.FromMilliseconds(0),
                 message,
                 "",
-                consoleOutput.TrimEnd('\n'));
+                consoleOutput);
             return result;
         }
 

--- a/GoogleTestAdapter/TestAdapter/DataConversionExtensions.cs
+++ b/GoogleTestAdapter/TestAdapter/DataConversionExtensions.cs
@@ -99,14 +99,6 @@ namespace GoogleTestAdapter.TestAdapter
                     testResult.StandardOutput));
             }
 
-            // Add standard error messages
-            if (!string.IsNullOrEmpty(testResult.StandardError))
-            {
-                result.Messages.Add(new Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResultMessage(
-                    Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResultMessage.StandardErrorCategory,
-                    testResult.StandardError));
-            }
-
             return result;
         }
 

--- a/GoogleTestAdapter/TestAdapter/DataConversionExtensions.cs
+++ b/GoogleTestAdapter/TestAdapter/DataConversionExtensions.cs
@@ -81,7 +81,7 @@ namespace GoogleTestAdapter.TestAdapter
 
         public static VsTestResult ToVsTestResult(this TestResult testResult)
         {
-            return new VsTestResult(ToVsTestCase(testResult.TestCase))
+            var result = new VsTestResult(ToVsTestCase(testResult.TestCase))
             {
                 Outcome = testResult.Outcome.ToVsTestOutcome(),
                 ComputerName = testResult.ComputerName,
@@ -90,6 +90,24 @@ namespace GoogleTestAdapter.TestAdapter
                 ErrorMessage = testResult.ErrorMessage,
                 ErrorStackTrace = testResult.ErrorStackTrace
             };
+
+            // Add standard output messages
+            if (!string.IsNullOrEmpty(testResult.StandardOutput))
+            {
+                result.Messages.Add(new Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResultMessage(
+                    Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResultMessage.StandardOutCategory,
+                    testResult.StandardOutput));
+            }
+
+            // Add standard error messages
+            if (!string.IsNullOrEmpty(testResult.StandardError))
+            {
+                result.Messages.Add(new Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResultMessage(
+                    Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResultMessage.StandardErrorCategory,
+                    testResult.StandardError));
+            }
+
+            return result;
         }
 
 


### PR DESCRIPTION
The current infrastructure combines the stdout and stderr streams into one stream. So by the time parsing happens the streams are already merged. Treat them as one stream and show the content as Standard Output in the Test Explorer test detail summary.