### PR TITLE
Fix GoogleTestAdapter parser race condition causing recurring Windows nightly crash.

### DIFF
--- a/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GoogleTestAdapter.DiaResolver;
 using GoogleTestAdapter.Model;
@@ -393,6 +394,73 @@ namespace GoogleTestAdapter.TestResults
             var expectedErrorMessage =
                 "before test\nExpected: 1\nTo be equal to: 2\nafter test";
             testResult.ErrorMessage.Should().Be(expectedErrorMessage);
+        }
+
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void ReportLine_ConcurrentFlush_DoesNotOvertakeIncompleteStateTransition()
+        {
+            const int timeoutMilliseconds = 5000;
+            var cases = new List<TestCase>
+            {
+                TestDataCreator.ToTestCase("Test.First", TestDataCreator.DummyExecutable, ""),
+                TestDataCreator.ToTestCase("Test.Second", TestDataCreator.DummyExecutable, "")
+            };
+            var reportedResults = new List<TestResult>();
+
+            using (var reportLinePaused = new ManualResetEventSlim())
+            using (var releaseReportLine = new ManualResetEventSlim())
+            using (var flushStarted = new ManualResetEventSlim())
+            {
+                MockFrameworkReporter
+                    .Setup(r => r.ReportTestResults(It.IsAny<IEnumerable<TestResult>>()))
+                    .Callback<IEnumerable<TestResult>>(results => reportedResults.AddRange(results));
+                MockFrameworkReporter
+                    .Setup(r => r.ReportTestsStarted(
+                        It.Is<IEnumerable<TestCase>>(testCases =>
+                            testCases.Single().FullyQualifiedName == "Test.Second")))
+                    .Callback(() =>
+                    {
+                        reportLinePaused.Set();
+                        releaseReportLine.Wait(timeoutMilliseconds).Should().BeTrue();
+                    });
+
+                var parser = new StreamingStandardOutputTestResultParser(
+                    cases, MockLogger.Object, MockFrameworkReporter.Object, String.Empty);
+                parser.ReportLine("[ RUN      ] Test.First");
+                parser.ReportLine("[       OK ] Test.First (1 ms)");
+
+                Task reportLineTask = Task.Run(() =>
+                    parser.ReportLine("[ RUN      ] Test.Second[       OK ] Test.Second (2 ms)"));
+                reportLinePaused.Wait(timeoutMilliseconds).Should().BeTrue();
+
+                Task flushTask = Task.Run(() =>
+                {
+                    flushStarted.Set();
+                    parser.Flush();
+                });
+                flushStarted.Wait(timeoutMilliseconds).Should().BeTrue();
+
+                bool flushCompletedBeforeRelease;
+                try
+                {
+                    flushCompletedBeforeRelease = flushTask.Wait(500);
+                }
+                finally
+                {
+                    releaseReportLine.Set();
+                }
+
+                Task.WaitAll(new[] { reportLineTask, flushTask }, timeoutMilliseconds).Should().BeTrue();
+
+                flushCompletedBeforeRelease.Should().BeFalse();
+                reportedResults.Select(result => result.TestCase.FullyQualifiedName)
+                    .Should().Equal("Test.First", "Test.Second");
+                parser.TestResults.Select(result => result.TestCase.FullyQualifiedName)
+                    .Should().Equal("Test.First", "Test.Second");
+                reportedResults.Should().OnlyContain(result => result.ErrorMessage == null);
+                parser.CrashedTestCase.Should().BeNull();
+            }
         }
 
         private IList<TestResult> GetTestResultsFromCompleteOutputFile()

--- a/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
@@ -27,6 +27,7 @@ namespace GoogleTestAdapter.TestResults
         private readonly ILogger _logger;
         private readonly ITestFrameworkReporter _reporter;
 
+        private readonly object _syncObject = new object();
         private readonly List<string> _consoleOutput = new List<string>();
         private readonly string _executable;
 
@@ -58,19 +59,22 @@ namespace GoogleTestAdapter.TestResults
 
         public void ReportLine(string line)
         {
-            Match testEndMatch = PrefixedLineRegex.Match(line);
-            if (testEndMatch.Success)
+            lock (_syncObject)
             {
-                string restOfErrorMessage = testEndMatch.Groups[1].Value;
-                if (!string.IsNullOrEmpty(restOfErrorMessage))
-                    DoReportLine(restOfErrorMessage);
+                Match testEndMatch = PrefixedLineRegex.Match(line);
+                if (testEndMatch.Success)
+                {
+                    string restOfErrorMessage = testEndMatch.Groups[1].Value;
+                    if (!string.IsNullOrEmpty(restOfErrorMessage))
+                        DoReportLine(restOfErrorMessage);
 
-                string testEndPart = testEndMatch.Groups[2].Value;
-                DoReportLine(testEndPart);
-            }
-            else
-            {
-                DoReportLine(line);
+                    string testEndPart = testEndMatch.Groups[2].Value;
+                    DoReportLine(testEndPart);
+                }
+                else
+                {
+                    DoReportLine(line);
+                }
             }
         }
 
@@ -95,10 +99,13 @@ namespace GoogleTestAdapter.TestResults
 
         public void Flush()
         {
-            if (_consoleOutput.Count > 0)
+            lock (_syncObject)
             {
-                ReportTestResult();
-                _consoleOutput.Clear();
+                if (_consoleOutput.Count > 0)
+                {
+                    ReportTestResult();
+                    _consoleOutput.Clear();
+                }
             }
         }
 


### PR DESCRIPTION
Summary:

Fix a race condition in StreamingStandardOutputTestResultParser that could occur when ReportLine() and Flush() access parser state concurrently.

Changes:

- Added synchronization using the existing _syncObject lock.
- Prevented concurrent access to parser state.
- Added regression coverage for the concurrency scenario.

 Validation:
- Successfully built the solution locally.
- Validated the fix through local test execution.
- Verified that the concurrency scenario passes after the fix.